### PR TITLE
Add more make targets for RPM fixtures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-/*-fixtures/
+/*-fixtures*/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-ALL = docker-fixtures rpm-fixtures
+ALL = docker-fixtures \
+    rpm-fixtures \
+    rpm-fixtures-invalid-updateinfo \
+    rpm-fixtures-updated-updateinfo
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of:"
@@ -7,6 +10,10 @@ help:
 	@echo "  all             to execute all following targets"
 	@echo "  docker-fixtures to create Docker fixture data"
 	@echo "  rpm-fixtures    to create RPM fixture data"
+	@echo "  rpm-fixtures-invalid-updateinfo"
+	@echo "                  to create RPM fixtures with updated updateinfo.xml"
+	@echo "  rpm-fixtures-updated-updateinfo"
+	@echo "                  to create RPM fixtures with invalid updateinfo.xml"
 
 clean:
 	rm -rf $(ALL)
@@ -18,5 +25,11 @@ docker-fixtures:
 
 rpm-fixtures:
 	rpm/gen-fixtures.sh $@ rpm/assets
+
+rpm-fixtures-invalid-updateinfo:
+	rpm/gen-patched-fixtures.sh $@ rpm/invalid-updateinfo.patch
+
+rpm-fixtures-updated-updateinfo:
+	rpm/gen-patched-fixtures.sh $@ rpm/updated-updateinfo.patch
 
 .PHONY: help clean all

--- a/rpm/gen-patched-fixtures.sh
+++ b/rpm/gen-patched-fixtures.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# WARNING: Calling this script by hand is not recommended. It should instead be
+# called by the pulp-fixtures make file. That's because this script doesn't
+# perform the same human-friendly input validation as `./gen-fixtures.sh`, and
+# it includes hard-coded relative paths.
+#
+# Usage:
+#
+#     gen-patched-assets.sh <output_dir> <updateinfo_patch>
+#
+# Behaviour:
+#
+# 1. Create a temporary directory.
+# 2. Copy assets into this directory.
+# 3. Apply a patch to assets_dir/updateinfo.xml.
+# 4. Call gen-fixtures.sh, and point it at our patched assets.
+# 5. Remove the temporary directory.
+#
+set -euo pipefail
+
+# Read arguments.
+output_dir="${1}"
+updateinfo_patch=$(realpath "${2}")
+
+# Define a procedure for graceful termination.
+cleanup() {
+    if [ -n "${assets_dir:-}" ]; then
+        rm -rf "${assets_dir}"
+    fi
+}
+trap cleanup EXIT  # bash pseudo signal
+trap 'cleanup ; trap - SIGINT ; kill -s SIGINT $$' SIGINT
+trap 'cleanup ; trap - SIGTERM ; kill -s SIGTERM $$' SIGTERM
+
+# Generate patched assets.
+assets_dir="$(mktemp --directory)"
+cp -rt "${assets_dir}" rpm/assets/*
+patch "${assets_dir}/updateinfo.xml" "${updateinfo_patch}"
+./rpm/gen-fixtures.sh "${output_dir}" "${assets_dir}"

--- a/rpm/invalid-updateinfo.patch
+++ b/rpm/invalid-updateinfo.patch
@@ -1,0 +1,40 @@
+--- rpm/assets/updateinfo.xml	2016-05-09 01:35:17.612160334 +0200
++++ rpm/assets/updateinfo-invalid-date.xml	2016-05-06 19:26:31.206643021 +0200
+@@ -5,7 +5,7 @@
+   <title>Sea_Erratum</title>
+   <release>1</release>
+   <issued date="2012-01-27 16:08:06"/>
+-  <updated date="2012-01-27 16:08:06"/>
++  <updated date="2012-01-27 16:08:06 CEST"/>
+   <description>Sea_Erratum</description>
+   <pkglist>
+     <collection short="">
+@@ -28,7 +28,7 @@
+   <title>Bird_Erratum</title>
+   <release>1</release>
+   <issued date="2013-01-27 16:08:08"/>
+-  <updated date="2013-02-27 17:00:00"/>
++  <updated date="2013-02-27 17:00"/>
+   <description>ParthaBird_Erratum</description>
+   <pkglist>
+     <collection short="">
+@@ -51,7 +51,7 @@
+   <title>Bear_ErratumPARTHA</title>
+   <release>1</release>
+   <issued date="2013-01-27 16:08:05"/>
+-  <updated date="2013-01-27 16:08:05 UTC"/>
++  <updated date="2013-01-27"/>
+   <description>Bear_Erratum</description>
+   <pkglist>
+     <collection short="">
+@@ -68,8 +68,8 @@
+   <title>Gorilla_Erratum</title>
+   <release>1</release>
+   <issued date="2013-01-27 16:08:09"/>
+-  <updated date="2014-07-20 06:00:01 UTC"/>
+-  <description>Gorilla_Erratum</description>
++  <updated date="2015-01-01 00:00:00 UTC"/>
++  <description>Updated Gorilla_Erratum</description>
+   <pkglist>
+     <collection short="">
+       <name>1</name>

--- a/rpm/updated-updateinfo.patch
+++ b/rpm/updated-updateinfo.patch
@@ -1,0 +1,42 @@
+--- rpm/assets/updateinfo.xml	2016-05-09 01:35:17.612160334 +0200
++++ rpm/assets/updateinfo-updated.xml	2016-05-06 19:29:50.869779588 +0200
+@@ -6,7 +6,7 @@
+   <release>1</release>
+   <issued date="2012-01-27 16:08:06"/>
+   <updated date="2012-01-27 16:08:06"/>
+-  <description>Sea_Erratum</description>
++  <description>Sea_Erratum you_should_not_see_this_sentence_in_the_database_if_it_was_the_update_of_this_erratum</description>
+   <pkglist>
+     <collection short="">
+       <name>1</name>
+@@ -28,8 +28,8 @@
+   <title>Bird_Erratum</title>
+   <release>1</release>
+   <issued date="2013-01-27 16:08:08"/>
+-  <updated date="2013-02-27 17:00:00"/>
+-  <description>ParthaBird_Erratum</description>
++  <updated date="2014-01-01 00:00:00"/>
++  <description>Updated ParthaBird_Erratum and the updated date does not contain timezone</description>
+   <pkglist>
+     <collection short="">
+       <name>1</name>
+@@ -52,7 +52,7 @@
+   <release>1</release>
+   <issued date="2013-01-27 16:08:05"/>
+   <updated date="2013-01-27 16:08:05 UTC"/>
+-  <description>Bear_Erratum</description>
++  <description>Bear_Erratum you_should_not_see_this_sentence_in_the_database_if_it_was_the_update_of_this_erratum</description>
+   <pkglist>
+     <collection short="">
+       <name>1</name>
+@@ -68,8 +68,8 @@
+   <title>Gorilla_Erratum</title>
+   <release>1</release>
+   <issued date="2013-01-27 16:08:09"/>
+-  <updated date="2014-07-20 06:00:01 UTC"/>
+-  <description>Gorilla_Erratum</description>
++  <updated date="2015-01-01 00:00:00 UTC"/>
++  <description>Updated Gorilla_Erratum and the updated date contains timezone</description>
+   <pkglist>
+     <collection short="">
+       <name>1</name>


### PR DESCRIPTION
Add two new make targets:

* `rpm-fixtures-invalid-updateinfo` generates RPM fixtures with an
  invalid `updateinfo.xml` file.
* `rpm-fixtures-updated-updateinfo` generates RPM fixtures with an
  updated `updateinfo.xml` file.

These new fixture generation targets make use of the existing RPM
assets, meaning that no duplicate data sets need to be maintained.

This commit derived from https://github.com/PulpQE/pulp-fixtures/pull/4.
(Thank you, @goosemania.)