### PR TITLE
Make `fixtures` depend on `fixtures/rpm-erratum`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ all: fixtures
 
 fixtures: fixtures/docker \
     fixtures/rpm \
+    fixtures/rpm-erratum \
     fixtures/rpm-invalid-updateinfo \
     fixtures/rpm-updated-updateinfo
 


### PR DESCRIPTION
The `fixtures` make target should depend on all of the other `fixtures/*` targets. Make it so. This should have been done in 5de5b01a22ff64cb14e0a453937b830f35a8a3ed.