### PR TITLE
Add make target: lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 help:
 	@echo "Please use \`make <target>' where <target> is one of:"
 	@echo "  help            to show this message"
+	@echo "  lint            to lint the fixture generation scripts"
 	@echo "  clean           to remove fixture data"
 	@echo "  fixtures        to create all fixture data"
 	@echo "  fixtures/docker to create Docker fixture data"
@@ -15,6 +16,10 @@ help:
 
 clean:
 	rm -rf fixtures/*
+
+# xargs communicates return values better than find's `-exec` argument.
+lint:
+	find . -name '*.sh' -print0 | xargs -0 shellcheck
 
 all: fixtures
 	$(warning The `all` target is deprecated. Use `fixtures` instead.)
@@ -44,4 +49,4 @@ fixtures/rpm-invalid-updateinfo:
 fixtures/rpm-updated-updateinfo:
 	rpm/gen-patched-fixtures.sh $@ rpm/updated-updateinfo.patch
 
-.PHONY: help clean all
+.PHONY: help lint clean all

--- a/README.rst
+++ b/README.rst
@@ -20,11 +20,14 @@ For exact usage instructions, clone this repository and run ``make help``.
 Dependencies
 ------------
 
-The fixture generation scripts do little more than call out to system utilities
-and mangle the results. It's the user's responsibility to ensure the necessary
-utilities are available and usable. Dependencies are listed below, according to
-make target. Common system utilities like ``fmt``, ``patch`` and ``realpath``
-are omitted.
+The make targets and fixture generation scripts do little more than call out to
+system utilities and mangle the results. It's the user's responsibility to
+ensure the necessary utilities are available and usable. Dependencies are listed
+below, according to make target. Common system utilities like ``fmt``, ``patch``
+and ``realpath`` are omitted.
+
+``lint``
+    The ``shellcheck`` executable must be available.
 
 ``fixtures/docker``
     The ``docker`` utility must be available.


### PR DESCRIPTION
The new make target uses the `shellcheck` executable to check all shell
scripts for issues.