### PR TITLE
Add json api to python fixture

### DIFF
--- a/python/assets/pypi/shelf-reader/json/index.html
+++ b/python/assets/pypi/shelf-reader/json/index.html
@@ -1,0 +1,27 @@
+{
+  "info": {
+    "author": "Austin Macdonald",
+    "name": "shelf-reader",
+    "summary": "Make sure your collections are in call number order."
+  },
+  "releases": {
+    "0.1": [
+      {
+        "md5_digest": "2dac570a33d88ca224be86759be59376",
+        "filename": "shelf-reader-0.1.tar.gz",
+        "packagetype": "sdist",
+        "checksum_type": "sha512",
+        "path": "..\/..\/..\/packages\/source\/s\/shelf-reader\/shelf-reader-0.1.tar.gz#sha512=4d11d6a67ec6aa3eb25df2416b6d48f1c6c04d5e745b12d7dbc89aacfc8bcb439c5ccff56324ce8493099e4e2f79a414d2513758782efcaef84b3d8cf00ea45f",
+        "checksum": "4d11d6a67ec6aa3eb25df2416b6d48f1c6c04d5e745b12d7dbc89aacfc8bcb439c5ccff56324ce8493099e4e2f79a414d2513758782efcaef84b3d8cf00ea45f"
+      },
+      {
+        "md5_digest": "69b867d206f1ff984651aeef25fc54f9",
+        "filename": "shelf_reader-0.1-py2-none-any.whl",
+        "packagetype": "bdist_wheel",
+        "checksum_type": "sha512",
+        "path": "..\/..\/..\/packages\/source\/s\/shelf-reader\/shelf_reader-0.1-py2-none-any.whl#sha512=1e38ac80980094ea9bb36a3ab9cb31476ac96c7839789caaf99f6bd170c1c12dd802f46270e25f1352380f40fac8f62ef85ddc0ca03bf25922c18a4b1ee04187",
+        "checksum": "1e38ac80980094ea9bb36a3ab9cb31476ac96c7839789caaf99f6bd170c1c12dd802f46270e25f1352380f40fac8f62ef85ddc0ca03bf25922c18a4b1ee04187"
+      }
+    ]
+  }
+}

--- a/python/assets/pypi/shelf-reader/json/index.json
+++ b/python/assets/pypi/shelf-reader/json/index.json
@@ -1,0 +1,27 @@
+{
+  "info": {
+    "author": "Austin Macdonald",
+    "name": "shelf-reader",
+    "summary": "Make sure your collections are in call number order."
+  },
+  "releases": {
+    "0.1": [
+      {
+        "md5_digest": "2dac570a33d88ca224be86759be59376",
+        "filename": "shelf-reader-0.1.tar.gz",
+        "packagetype": "sdist",
+        "checksum_type": "sha512",
+        "path": "..\/..\/..\/packages\/source\/s\/shelf-reader\/shelf-reader-0.1.tar.gz#sha512=4d11d6a67ec6aa3eb25df2416b6d48f1c6c04d5e745b12d7dbc89aacfc8bcb439c5ccff56324ce8493099e4e2f79a414d2513758782efcaef84b3d8cf00ea45f",
+        "checksum": "4d11d6a67ec6aa3eb25df2416b6d48f1c6c04d5e745b12d7dbc89aacfc8bcb439c5ccff56324ce8493099e4e2f79a414d2513758782efcaef84b3d8cf00ea45f"
+      },
+      {
+        "md5_digest": "69b867d206f1ff984651aeef25fc54f9",
+        "filename": "shelf_reader-0.1-py2-none-any.whl",
+        "packagetype": "bdist_wheel",
+        "checksum_type": "sha512",
+        "path": "..\/..\/..\/packages\/source\/s\/shelf-reader\/shelf_reader-0.1-py2-none-any.whl#sha512=1e38ac80980094ea9bb36a3ab9cb31476ac96c7839789caaf99f6bd170c1c12dd802f46270e25f1352380f40fac8f62ef85ddc0ca03bf25922c18a4b1ee04187",
+        "checksum": "1e38ac80980094ea9bb36a3ab9cb31476ac96c7839789caaf99f6bd170c1c12dd802f46270e25f1352380f40fac8f62ef85ddc0ca03bf25922c18a4b1ee04187"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Mimics the json api of PyPI. The actual structure and files are produced
by a pulp publish so this effectively tests a pulp to pulp sync as well.