### PR TITLE
Simplify DRPM generation script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ fixtures/docker:
 	docker/gen-fixtures.sh $@
 
 fixtures/drpm-unsigned:
-	rpm/gen-fixtures-delta.sh $@ rpm/assets-drpm test-alpha
+	rpm/gen-fixtures-delta.sh $@ rpm/assets-drpm
 	rpm/del-fixtures-sign.sh $@
 
 fixtures/python:


### PR DESCRIPTION
The DRPM generation script has the following signature:

    gen-fixtures-delta.sh <output_dir> <assets_dir> <dpkg_name>

The `dpkg_name` argument is used to select which RPMs in `assets_dir`
should be used when generating DRPMs. This argument is redundant, as the
assets shipped with Pulp Fixtures (in `rpm/assets-drpm/`) all have the
same base package name. In addition, there is no foreseeable need for
this argument. Change the script signature to:

    gen-fixtures-delta.sh <output_dir> <assets_dir>

In addition, refactor the existing error checking within the script.
(Dropping `dpkg_name` makes this refactor easier to perform.)

This change has no impact on the files generated by any make target,
including `fixtures/drpm-unsigned`.