### PR TITLE
Add a 'fixtures/drpm' make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ help:
 	@echo "  clean           to remove fixture data and 'gnupghome'"
 	@echo "  fixtures        to create all fixture data"
 	@echo "  fixtures/docker to create Docker fixture data"
+	@echo "  fixtures/drpm   to create DRPM fixture data with signed packages"
 	@echo "  fixtures/drpm-unsigned"
 	@echo "                  to create DRPM fixtures with unsigned packages"
 	@echo "  fixtures/python to create Python fixture data"
@@ -38,6 +39,7 @@ all: fixtures
 	$(warning The `all` target is deprecated. Use `fixtures` instead.)
 
 fixtures: fixtures/docker \
+	fixtures/drpm \
 	fixtures/drpm-unsigned \
 	fixtures/python \
 	fixtures/rpm \
@@ -51,6 +53,12 @@ fixtures: fixtures/docker \
 
 fixtures/docker:
 	docker/gen-fixtures.sh $@
+
+fixtures/drpm: gnupghome
+	rpm/gen-fixtures-delta.sh $@ rpm/assets-drpm
+	GNUPGHOME=$$(realpath -e gnupghome) rpmsign --define '_gpg_name Pulp QE' \
+		--addsign --fskpath ./rpm/GPG-RPM-PRIVATE-KEY-pulp-qe --signfiles \
+		$$(find $@ -name '*.drpm')
 
 fixtures/drpm-unsigned:
 	rpm/gen-fixtures-delta.sh $@ rpm/assets-drpm

--- a/README.rst
+++ b/README.rst
@@ -44,6 +44,9 @@ See ``make help``.
     permissions, with a command such as ``gpasswd --add $(id -u) docker &&
     newgrp``.
 
+``fixtures/drpm``
+    The ``createrepo``, ``makedeltarpm`` and ``rpmsign`` utilities must be available.
+
 ``fixtures/drpm-unsigned``
     The ``createrepo`` and ``makedeltarpm`` executables must be available.
 
@@ -92,7 +95,9 @@ Package Signatures
 The RPM, SRPM and DRPM assets are unsigned, and signatures are added as needed
 when generating fixtures. The opposite approach of using signed assets and
 stripping signatures as needed is less safe, as the keypair can more easily go
-out of sync with the assets.
+out of sync with the assets. In addition, the ``makedeltarpm`` utility generates
+unsigned DRPMs, meaning the ``fixtures/drpm`` target must perform package
+signing.
 
 By default, GnuPG works with files in the ``~/.gnupg`` directory, and the
 ``rpmsign`` executable works with the ``~/.rpmmacros`` file. (Other RPM


### PR DESCRIPTION
Unlike 'fixtures/drpm-unsigned', this make target generates signed
DRPMs.

Fix: https://github.com/PulpQE/pulp-fixtures/issues/25