### PR TITLE
Fix bug in RPM package signing procedure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,10 +67,8 @@ fixtures/python:
 	python/gen-fixtures.sh $@ python/assets
 
 fixtures/rpm: gnupghome
-	rpm/gen-fixtures.sh $@ rpm/assets
-	GNUPGHOME=$$(realpath -e gnupghome) rpmsign --define '_gpg_name Pulp QE' \
-		--addsign --fskpath ./rpm/GPG-RPM-PRIVATE-KEY-pulp-qe --signfiles \
-		$$(find $@ -name '*.rpm')
+	GNUPGHOME=$$(realpath -e gnupghome) rpm/gen-fixtures.sh \
+		--signing-key ./rpm/GPG-RPM-PRIVATE-KEY-pulp-qe $@ rpm/assets
 
 fixtures/rpm-erratum:
 	rpm/gen-erratum.sh $@ rpm/assets
@@ -88,10 +86,8 @@ fixtures/rpm-updated-updateinfo:
 	rpm/gen-patched-fixtures.sh $@ rpm/updated-updateinfo.patch
 
 fixtures/srpm: gnupghome
-	rpm/gen-fixtures.sh $@ rpm/assets-srpm
-	GNUPGHOME=$$(realpath -e gnupghome) rpmsign --define '_gpg_name Pulp QE' \
-		--addsign --fskpath ./rpm/GPG-RPM-PRIVATE-KEY-pulp-qe --signfiles \
-		$$(find $@ -name '*.src.rpm')
+	GNUPGHOME=$$(realpath -e gnupghome) rpm/gen-fixtures.sh \
+		--signing-key ./rpm/GPG-RPM-PRIVATE-KEY-pulp-qe $@ rpm/assets-srpm
 
 fixtures/srpm-unsigned:
 	rpm/gen-fixtures.sh $@ rpm/assets-srpm

--- a/rpm/gen-fixtures.sh
+++ b/rpm/gen-fixtures.sh
@@ -1,52 +1,92 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 #
-# Generate RPM repository fixture data. Several RPM utilities must be installed,
-# including `createrepo` and `modifyrepo`.
+# Generate an RPM repository.
+
+# TODO move check_getopt to a separate script
 #
 set -euo pipefail
 
-# NOTE: $0 corresponds to the the script's name only in some shells and in some
-# contexts.
+# See: http://mywiki.wooledge.org/BashFAQ/028
+readonly script_name='gen-fixtures.sh'
+
+# Print usage instructions to stdout.
 show_help() {
 fmt <<EOF
-usage: gen-fixtures.sh <output_dir> <assets_dir>
+Usage: $script_name [options] <output-dir> <assets-dir>
 
-Create <output_dir>. Use <assets_dir> to generate RPM fixture data and place the
-results into <output_dir>. A suggested name for <output_dir> is "zoo".
+Generate an RPM repository from the RPMs in <assets-dir>. Place the repository's
+contents into <output-dir>. <output-dir> need not exist, but all parent
+directories must exist.
 
-EOF
-cat <<EOF
-<output_dir>
-    The directory into which generated fixtures are placed.
-<assets_dir>
-    The directory from which source material is read.
+Options:
+    --signing-key <signing-key>
+        A private key with which to sign RPMs in the generated repository. The
+        corresponding public key must have a uid (name) of "Pulp QE". (You can
+        check this by executing 'gpg public-key' and examining the "uid" field.)
 EOF
 }
 
-# Fetch output_dir from user.
-if [ "$#" -lt 2 ]; then
-    echo 1>&2 'Error: Too few arguments received.'
-    echo 1>&2
-    show_help 1>&2
-    exit 1
-elif [ "$#" -gt 2 ]; then
-    echo 1>&2 'Error: Too many arguments received.'
-    echo 1>&2
-    show_help 1>&2
-    exit 1
-else
-    output_dir="$(realpath --canonicalize-missing "${1}")"
-    assets_dir="$(realpath "${2}")"
-fi
+# Verify that getopt(1) supports modern option parsing.
+check_getopt() {
+    if [ "$(getopt --test || true)" != '' ]; then
+        fmt 1>&2 <<EOF
+An old version of getopt is installed. Its limitations include being unable to
+cope with whitespace and other shell-specific special characters. Please upgrade
+getopt, or execute this script on a more up-to-date system.
 
-# Create output_dir and generate fixture data from assets_dir.
+Execute 'getopt --test' to see if getopt is new enough. A modern getopt will
+print no output and return 4. A traditional getopt will print '--' and return 0.
+For more information, see getopt(1).
+
+This script will now exit, so as to avoid possibly causing damage.
+EOF
+        exit 1
+    fi
+}
+
+# Transform $@. $temp is needed. If omitted, non-zero exit codes are ignored.
+check_getopt
+temp=$(getopt --options '' --longoptions signing-key: --name "$script_name" -- "$@")
+eval set -- "$temp"
+unset temp
+
+# Read arguments. (getopt inserts -- even when no arguments are passed.)
+if [ "${#@}" -eq 1 ]; then
+    show_help
+    exit 0
+fi
+while true; do
+    case "$1" in
+        --signing-key) signing_key="$(realpath --canonicalize-existing "$2")"; shift 2;;
+        --) shift; break;;
+        *) echo "Internal error! Encountered unexpected argument: $1"; exit 1;;
+    esac
+done
+output_dir="$(realpath "$1")"
+assets_dir="$(realpath --canonicalize-existing "$2")"
+shift 2
+
+# Create a workspace, and schedule it for deletion.
+cleanup() { if [ -n "${working_dir:-}" ]; then rm -rf "${working_dir}"; fi }
+trap cleanup EXIT  # bash pseudo signal
+trap 'cleanup ; trap - SIGINT ; kill -s SIGINT $$' SIGINT
+trap 'cleanup ; trap - SIGTERM ; kill -s SIGTERM $$' SIGTERM
+working_dir="$(mktemp --directory)"
+
+# Generate a repository and move it to $output_dir when done.
+#
 # NOTE: --groupfile should not be in $output_dir, but createrepo requires that
 # --groupfile be relative to $output_dir. Thus, the relative path calculation.
-mkdir "${output_dir}"
-cp -t "${output_dir}" "${assets_dir}/"*.rpm
+cp --reflink=auto -t "${working_dir}" "${assets_dir}/"*.rpm
+if [ -n "${signing_key:-}" ]; then
+    find "${working_dir}" -name '*.rpm' -print0 | xargs -0 rpmsign \
+        --define '_gpg_name Pulp QE' --addsign --fskpath "${signing_key}" \
+        --signfiles
+fi
 createrepo --checksum sha256 \
-    --groupfile "$(realpath --relative-to "${output_dir}" "${assets_dir}/comps.xml")" \
-    "${output_dir}"
+    --groupfile "$(realpath --relative-to "${working_dir}" "${assets_dir}/comps.xml")" \
+    "${working_dir}"
 modifyrepo --mdtype updateinfo \
     "${assets_dir}/updateinfo.xml" \
-    "${output_dir}/repodata/"
+    "${working_dir}/repodata/"
+cp --reflink=auto -r "${working_dir}" "${output_dir}"


### PR DESCRIPTION
The `fixtures/rpm`, `fixtures/drpm` and `fixtures/srpm` make targets
generate repositories with incorrect metadata. The issue is that, when
creating a signed repository, packages and metadata are written to the
destination directory before package signing is performed. When packages
are signed, the existing metadata is no longer accurate. Of special
interest is that package checksums and sizes are no longer accurate.

Fix the `fixtures/rpm` and `fixtures/srpm` make targets, so that package
signing is performed before repository metadata is generated.

See: https://github.com/PulpQE/pulp-fixtures/issues/32