### PR TITLE
Fix bug in DRPM package signing procedure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,10 +55,8 @@ fixtures/docker:
 	docker/gen-fixtures.sh $@
 
 fixtures/drpm: gnupghome
-	rpm/gen-fixtures-delta.sh $@ rpm/assets-drpm
-	GNUPGHOME=$$(realpath -e gnupghome) rpmsign --define '_gpg_name Pulp QE' \
-		--addsign --fskpath ./rpm/GPG-RPM-PRIVATE-KEY-pulp-qe --signfiles \
-		$$(find $@ -name '*.drpm')
+	GNUPGHOME=$$(realpath -e gnupghome) rpm/gen-fixtures-delta.sh \
+		--signing-key ./rpm/GPG-RPM-PRIVATE-KEY-pulp-qe $@ rpm/assets-drpm
 
 fixtures/drpm-unsigned:
 	rpm/gen-fixtures-delta.sh $@ rpm/assets-drpm

--- a/rpm/common.sh
+++ b/rpm/common.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+#
+# Re-usable functions for use by the other RPM-generation scripts.
+
+# Verify that getopt(1) supports modern option parsing.
+check_getopt() {
+    if [ "$(getopt --test || true)" != '' ]; then
+        fmt 1>&2 <<EOF
+An old version of getopt is installed. Its limitations include being unable to
+cope with whitespace and other shell-specific special characters. Please upgrade
+getopt, or execute this script on a more up-to-date system.
+
+Execute 'getopt --test' to see if getopt is new enough. A modern getopt will
+print no output and return 4. A traditional getopt will print '--' and return 0.
+For more information, see getopt(1).
+
+This script will now exit, so as to avoid possibly causing damage.
+EOF
+        exit 1
+    fi
+}

--- a/rpm/gen-fixtures-delta.sh
+++ b/rpm/gen-fixtures-delta.sh
@@ -1,37 +1,35 @@
 #!/usr/bin/env bash
 #
 # Generate RPM repository with DRPM fixture data.
-# Several RPM utilities must be installed, including `createrepo` and `makedeltarpm`.
 #
 set -euo pipefail
 
-#------------------------------------------------------------------------------
-# Helper Functions
-#------------------------------------------------------------------------------
+# Assume this script has been called from the Pulp Fixtures makefile.
+source ./rpm/common.sh
 
-# Print a message to stdout explaining how to use this script.
-#
-# NOTE: $0 corresponds to the the script's name only in some shells and in some
-# contexts.
+# See: http://mywiki.wooledge.org/BashFAQ/028
+readonly script_name='gen-fixtures-delta.sh'
+
+# Print usage instructions to stdout.
 show_help() {
 fmt <<EOF
-usage: gen-fixtures-delta.sh <output_dir> <assets_dir>
+Usage: $script_name [options] <output-dir> <assets-dir>
 
-Create <output_dir>. Walk through the RPMs in <assets_dir>, and generate a DRPM
-for each adjacent pair of RPMs. Copy the source RPMs to <output_dir>, and place
-the generated DRPMs in <output_dir>/drpms.
+Generate a DRPM repository from the RPMs in <assets-dir>. Place the repository's
+contents into <output-dir>, with RPMs in <output-dir> and DRPMs in
+<output-dir>/drpms. <output-dir> need not exist, but all parent directories must
+exist.
 
-The RPMs in <assets_dir> should be related. (It doesn't make sense to generate a
-DRPM for upgrading from firefox to gimp.) This script will exit with a non-zero
-exit code if any adjacent pair of RPMs have differing base package names or
-architectures.
+Exit with a non-zero exit code if any adjacent pair of RPMs in <assets-dir> have
+differing base package names or architectures. (In other words, the source RPMs
+must be related. It doesn't make sense to generate a DRPM for upgrading from
+firefox to gimp.)
 
-EOF
-cat <<EOF
-<output_dir>
-    The directory into which generated fixtures are placed.
-<assets_dir>
-    The directory from which RPMs are read.
+Options:
+    --signing-key <signing-key>
+        A private key with which to sign DRPMs in the generated repository. The
+        corresponding public key must have a uid (name) of "Pulp QE". (You can
+        check this by executing 'gpg public-key' and examining the "uid" field.)
 EOF
 }
 
@@ -88,26 +86,38 @@ get_rpm_arch() {
 # Business Logic
 #------------------------------------------------------------------------------
 
-# Fetch output_dir from user.
-if [ "$#" -lt 2 ]; then
-    echo 1>&2 'Error: Too few arguments received.'
-    echo 1>&2
-    show_help 1>&2
-    exit 1
-elif [ "$#" -gt 2 ]; then
-    echo 1>&2 'Error: Too many arguments received.'
-    echo 1>&2
-    show_help 1>&2
-    exit 1
-else
-    output_dir="$(realpath --canonicalize-missing "${1}")"
-    assets_dir="$(realpath --canonicalize-existing "${2}")"
-fi
+# Transform $@. $temp is needed. If omitted, non-zero exit codes are ignored.
+check_getopt
+temp=$(getopt --options '' --longoptions signing-key: --name "$script_name" -- "$@")
+eval set -- "$temp"
+unset temp
 
-# Create and populate ${output_dir}, and verify that we have enough RPMs.
-mkdir -vp "${output_dir}/drpms"
-cp -t "${output_dir}" "${assets_dir}/"*.rpm
-rpms=( "${output_dir}/"*.rpm )
+# Read arguments. (getopt inserts -- even when no arguments are passed.)
+if [ "${#@}" -eq 1 ]; then
+    show_help
+    exit 0
+fi
+while true; do
+    case "$1" in
+        --signing-key) signing_key="$(realpath --canonicalize-existing "$2")"; shift 2;;
+        --) shift; break;;
+        *) echo "Internal error! Encountered unexpected argument: $1"; exit 1;;
+    esac
+done
+output_dir="$(realpath "$1")"
+assets_dir="$(realpath --canonicalize-existing "$2")"
+shift 2
+
+# Create a workspace, and schedule it for deletion.
+cleanup() { if [ -n "${working_dir:-}" ]; then rm -rf "${working_dir}"; fi }
+trap cleanup EXIT  # bash pseudo signal
+trap 'cleanup ; trap - SIGINT ; kill -s SIGINT $$' SIGINT
+trap 'cleanup ; trap - SIGTERM ; kill -s SIGTERM $$' SIGTERM
+working_dir="$(mktemp --directory)"
+
+# Copy RPMs to workspace, and verify that we have enough RPMs.
+cp --reflink=auto -t "${working_dir}" "${assets_dir}/"*.rpm
+rpms=( "${working_dir}/"*.rpm )
 readonly num_rpms=${#rpms[@]}
 readonly num_needed=2
 if [ "${num_rpms}"  -lt "${num_needed}" ]; then
@@ -116,6 +126,7 @@ if [ "${num_rpms}"  -lt "${num_needed}" ]; then
 fi
 
 # Make DRPMs from RPMs.
+mkdir "${working_dir}/drpms"
 IFS=$'\n' rpms=($(sort <<<"${rpms[*]}"))  # sort files by name
 for (( i=0; i < num_rpms - 1; i++ )); do
     rpm_1="${rpms[i]}"
@@ -146,8 +157,16 @@ EOF
     rel_1="$(get_rpm_release "${rpm_1}" "${arch_1}")"
     rel_2="$(get_rpm_release "${rpm_2}" "${arch_2}")"
     makedeltarpm "${rpm_1}" "${rpm_2}" \
-        "${output_dir}/drpms/${name_2}-${ver_1}-${rel_1}_${ver_2}-${rel_2}.${arch_2}.drpm"
+        "${working_dir}/drpms/${name_2}-${ver_1}-${rel_1}_${ver_2}-${rel_2}.${arch_2}.drpm"
 done
 
-# Generate repodata directory.
-createrepo --checksum sha256 --deltas "${output_dir}"
+# Sign DRPMs and generate repository metadata.
+if [ -n "${signing_key:-}" ]; then
+    find "${working_dir}" -name '*.drpm' -print0 | xargs -0 rpmsign \
+        --define '_gpg_name Pulp QE' --addsign --fskpath "${signing_key}" \
+        --signfiles
+fi
+createrepo --checksum sha256 --deltas "${working_dir}"
+
+# Copy fixtures to $output_dir. For an explanation, see gen-fixtures.sh.
+cp -r --no-preserve=mode --reflink=auto "${working_dir}" "${output_dir}"

--- a/rpm/gen-fixtures.sh
+++ b/rpm/gen-fixtures.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 #
 # Generate an RPM repository.
-
-# TODO move check_getopt to a separate script
 #
 set -euo pipefail
+
+# Assume this script has been called from the Pulp Fixtures makefile.
+source ./rpm/common.sh
 
 # See: http://mywiki.wooledge.org/BashFAQ/028
 readonly script_name='gen-fixtures.sh'
@@ -24,24 +25,6 @@ Options:
         corresponding public key must have a uid (name) of "Pulp QE". (You can
         check this by executing 'gpg public-key' and examining the "uid" field.)
 EOF
-}
-
-# Verify that getopt(1) supports modern option parsing.
-check_getopt() {
-    if [ "$(getopt --test || true)" != '' ]; then
-        fmt 1>&2 <<EOF
-An old version of getopt is installed. Its limitations include being unable to
-cope with whitespace and other shell-specific special characters. Please upgrade
-getopt, or execute this script on a more up-to-date system.
-
-Execute 'getopt --test' to see if getopt is new enough. A modern getopt will
-print no output and return 4. A traditional getopt will print '--' and return 0.
-For more information, see getopt(1).
-
-This script will now exit, so as to avoid possibly causing damage.
-EOF
-        exit 1
-    fi
 }
 
 # Transform $@. $temp is needed. If omitted, non-zero exit codes are ignored.


### PR DESCRIPTION
The first commit performs a simple refactor. It moves `check_getopt` from its current script to `rpm/common.sh`. The second commit fixes the `fixtures/drpm` make target.