### PR TITLE
Fix permissions of generated fixtures

### DIFF
--- a/rpm/gen-fixtures.sh
+++ b/rpm/gen-fixtures.sh
@@ -73,7 +73,7 @@ trap 'cleanup ; trap - SIGINT ; kill -s SIGINT $$' SIGINT
 trap 'cleanup ; trap - SIGTERM ; kill -s SIGTERM $$' SIGTERM
 working_dir="$(mktemp --directory)"
 
-# Generate a repository and move it to $output_dir when done.
+# Sign RPMs and genereate repository metadata.
 #
 # NOTE: --groupfile should not be in $output_dir, but createrepo requires that
 # --groupfile be relative to $output_dir. Thus, the relative path calculation.
@@ -89,4 +89,13 @@ createrepo --checksum sha256 \
 modifyrepo --mdtype updateinfo \
     "${assets_dir}/updateinfo.xml" \
     "${working_dir}/repodata/"
-cp --reflink=auto -r "${working_dir}" "${output_dir}"
+
+# Copy fixtures to $output_dir.
+#
+# A $working_dir is used to make fixture generation more atomic. If fixture
+# generation fails, this script (or the calling make target) can be run again
+# without worrying about cleanup work. $working_dir is copied rather than moved
+# to prevent cleanup() from reaping an innocent directory. --no-preserve is used
+# because `mktemp -d` creates directories with a mode of 700, and a mode of 755
+# (or whatever the umask dictates) is desired.
+cp -r --no-preserve=mode --reflink=auto "${working_dir}" "${output_dir}"


### PR DESCRIPTION
`mktemp --directory` creates directories with mode 700, minus umask
restrictions. In addition, `rpm/gen-fixtures.sh` does its work in a
temporary directory before copying the results to the final directory.
As a result, make targets such as `fixtures/rpm` and
`fixtures/rpm-unsigned` create directories with permissions of 700. When
these files are copied to a web server, these permissions may make it
impossible to serve these files.

Fix this issue. Ensure that the top-level directories created by
`rpm/gen-fixtures.sh` don't have overly restrictive permissions.

Thanks to @dkliban for help in finding a fix.