### PR TITLE
Drop backslashes from paths

### DIFF
--- a/python/assets/pypi/shelf-reader/json/index.html
+++ b/python/assets/pypi/shelf-reader/json/index.html
@@ -11,7 +11,7 @@
         "filename": "shelf-reader-0.1.tar.gz",
         "packagetype": "sdist",
         "checksum_type": "sha512",
-        "path": "..\/..\/..\/packages\/source\/s\/shelf-reader\/shelf-reader-0.1.tar.gz#sha512=4d11d6a67ec6aa3eb25df2416b6d48f1c6c04d5e745b12d7dbc89aacfc8bcb439c5ccff56324ce8493099e4e2f79a414d2513758782efcaef84b3d8cf00ea45f",
+        "path": "../../../packages/source/s/shelf-reader/shelf-reader-0.1.tar.gz#sha512=4d11d6a67ec6aa3eb25df2416b6d48f1c6c04d5e745b12d7dbc89aacfc8bcb439c5ccff56324ce8493099e4e2f79a414d2513758782efcaef84b3d8cf00ea45f",
         "checksum": "4d11d6a67ec6aa3eb25df2416b6d48f1c6c04d5e745b12d7dbc89aacfc8bcb439c5ccff56324ce8493099e4e2f79a414d2513758782efcaef84b3d8cf00ea45f"
       },
       {
@@ -19,7 +19,7 @@
         "filename": "shelf_reader-0.1-py2-none-any.whl",
         "packagetype": "bdist_wheel",
         "checksum_type": "sha512",
-        "path": "..\/..\/..\/packages\/source\/s\/shelf-reader\/shelf_reader-0.1-py2-none-any.whl#sha512=1e38ac80980094ea9bb36a3ab9cb31476ac96c7839789caaf99f6bd170c1c12dd802f46270e25f1352380f40fac8f62ef85ddc0ca03bf25922c18a4b1ee04187",
+        "path": "../../../packages/source/s/shelf-reader/shelf_reader-0.1-py2-none-any.whl#sha512=1e38ac80980094ea9bb36a3ab9cb31476ac96c7839789caaf99f6bd170c1c12dd802f46270e25f1352380f40fac8f62ef85ddc0ca03bf25922c18a4b1ee04187",
         "checksum": "1e38ac80980094ea9bb36a3ab9cb31476ac96c7839789caaf99f6bd170c1c12dd802f46270e25f1352380f40fac8f62ef85ddc0ca03bf25922c18a4b1ee04187"
       }
     ]

--- a/python/assets/pypi/shelf-reader/json/index.json
+++ b/python/assets/pypi/shelf-reader/json/index.json
@@ -11,7 +11,7 @@
         "filename": "shelf-reader-0.1.tar.gz",
         "packagetype": "sdist",
         "checksum_type": "sha512",
-        "path": "..\/..\/..\/packages\/source\/s\/shelf-reader\/shelf-reader-0.1.tar.gz#sha512=4d11d6a67ec6aa3eb25df2416b6d48f1c6c04d5e745b12d7dbc89aacfc8bcb439c5ccff56324ce8493099e4e2f79a414d2513758782efcaef84b3d8cf00ea45f",
+        "path": "../../../packages/source/s/shelf-reader/shelf-reader-0.1.tar.gz#sha512=4d11d6a67ec6aa3eb25df2416b6d48f1c6c04d5e745b12d7dbc89aacfc8bcb439c5ccff56324ce8493099e4e2f79a414d2513758782efcaef84b3d8cf00ea45f",
         "checksum": "4d11d6a67ec6aa3eb25df2416b6d48f1c6c04d5e745b12d7dbc89aacfc8bcb439c5ccff56324ce8493099e4e2f79a414d2513758782efcaef84b3d8cf00ea45f"
       },
       {
@@ -19,7 +19,7 @@
         "filename": "shelf_reader-0.1-py2-none-any.whl",
         "packagetype": "bdist_wheel",
         "checksum_type": "sha512",
-        "path": "..\/..\/..\/packages\/source\/s\/shelf-reader\/shelf_reader-0.1-py2-none-any.whl#sha512=1e38ac80980094ea9bb36a3ab9cb31476ac96c7839789caaf99f6bd170c1c12dd802f46270e25f1352380f40fac8f62ef85ddc0ca03bf25922c18a4b1ee04187",
+        "path": "../../../packages/source/s/shelf-reader/shelf_reader-0.1-py2-none-any.whl#sha512=1e38ac80980094ea9bb36a3ab9cb31476ac96c7839789caaf99f6bd170c1c12dd802f46270e25f1352380f40fac8f62ef85ddc0ca03bf25922c18a4b1ee04187",
         "checksum": "1e38ac80980094ea9bb36a3ab9cb31476ac96c7839789caaf99f6bd170c1c12dd802f46270e25f1352380f40fac8f62ef85ddc0ca03bf25922c18a4b1ee04187"
       }
     ]


### PR DESCRIPTION
Change paths separators from `\/` to `/`. (For example, change path
`foo\/bar\/biz` to `foo/bar/biz`.) Do this because:

* This is what PyPi does. For example, see
  https://pypi.python.org/pypi/shelf-reader/json/
* The backslashes are likely escape characters. The correct syntax for
  paths is without escapes, and any escaping that needs to be done is an
  application-specific issue.

Related to: a639bff7feb780c52346c7d00865450c82097100