### PR TITLE
Give unbound variable a default value

### DIFF
--- a/rpm/gen-fixtures.sh
+++ b/rpm/gen-fixtures.sh
@@ -65,7 +65,7 @@ trap cleanup EXIT  # bash pseudo signal
 trap 'cleanup ; trap - SIGINT ; kill -s SIGINT $$' SIGINT
 trap 'cleanup ; trap - SIGTERM ; kill -s SIGTERM $$' SIGTERM
 working_dir="$(mktemp --directory)"
-packages_dir="$(realpath --canonicalize-missing "${working_dir}/${packages_dir}")"
+packages_dir="$(realpath --canonicalize-missing "${working_dir}/${packages_dir:-}")"
 if [ "${working_dir}" != "${packages_dir}" ]; then
     mkdir -p "${packages_dir}"
 fi


### PR DESCRIPTION
If `rpm/gen-fixtures.sh` is called with `--packages-dir
<relative-path>`, then an internal variable named `$packages_dir` is
set. If called without that flag, the internal `$packages_dir` variable
is not set, which leads to an unbound variable error. Fix this issue by
giving `$packages_dir` a default value for those cases where
`rpm/gen-fixtures.sh` is called without `--packages-dir`.

This change fixes targets such as `fixtures/rpm-unsigned`.