### PR TITLE
Use shellcheck 4.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ before_install:
     - cabal update
     - git clone https://github.com/koalaman/shellcheck.git
     - cd shellcheck
+    - git checkout v0.4.4
     - cabal install
     - cd ..
     - export PATH="$HOME/.cabal/bin:$PATH"


### PR DESCRIPTION
Shellcheck 4.5 is raising errors when installing, use 4.4 instead to make sure
Travis will produce sane results.