### PR TITLE
Add file fixtures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,10 @@ help:
 	@echo "                  to create DRPM fixtures with signed packages"
 	@echo "  fixtures/drpm-unsigned"
 	@echo "                  to create DRPM fixtures with unsigned packages"
+	@echo "  fixtures/file   to create File fixtures"
+	@echo "  fixtures/file-mixed"
+	@echo "                  to create File fixtures with some not available"
+	@echo "                  files on the PULP_MANIFEST"
 	@echo "  fixtures/python-pulp"
 	@echo "                  to create a Pulp Python repository"
 	@echo "  fixtures/python-pypi [base_url=...]"
@@ -65,6 +69,8 @@ fixtures: fixtures/docker \
 	fixtures/drpm \
 	fixtures/drpm-signed \
 	fixtures/drpm-unsigned \
+	fixtures/file \
+	fixtures/file-mixed \
 	fixtures/python \
 	fixtures/python-pulp \
 	fixtures/python-pypi \
@@ -96,6 +102,14 @@ fixtures/drpm-signed: gnupghome
 
 fixtures/drpm-unsigned:
 	rpm/gen-fixtures-delta.sh $@ rpm/assets-drpm
+
+fixtures/file:
+	file/gen-fixtures.sh $@
+
+fixtures/file-mixed:
+	file/gen-fixtures.sh $@
+	echo missing-1.iso,4a36e4eede4a61fd547040b53b1656b6dd489bd5bc4c0dd5fe55892dcf1669e8,1048576 >> $@/PULP_MANIFEST
+	echo missing-2.iso,ab6d91d4956d1a009bd6d03b3591f95aaae83b36907f77dd1ac71c400715b901,2097152 >> $@/PULP_MANIFEST
 
 fixtures/python: fixtures/python-pulp
 	$(warning The `fixtures/python` target is deprecated. Use `fixtures/python-pulp` instead.)

--- a/file/gen-fixtures.sh
+++ b/file/gen-fixtures.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+#
+# Generate a file repository.
+#
+set -euo pipefail
+
+# Print usage instructions to stdout.
+show_help() {
+fmt <<EOF
+Usage: gen-fixtures.sh <output-dir>
+
+Generate a file repository with pseudo ISO files (generated with bytes from
+/dev/urandom) with different filesize. Then generate the PULP_MANIFEST file
+describring the generated files.
+
+Place the repository's contents into <output-dir>. <output-dir> need not exist,
+but all parent directories must exist.
+EOF
+}
+
+# Fetch output_dir from user.
+if [ "$#" -lt 1 ]; then
+    echo 1>&2 'Error: Too few arguments received.'
+    echo 1>&2
+    show_help 1>&2
+    exit 1
+elif [ "$#" -gt 1 ]; then
+    echo 1>&2 'Error: Too many arguments received.'
+    echo 1>&2
+    show_help 1>&2
+    exit 1
+else
+    output_dir="$(realpath --canonicalize-missing "${1}")"
+fi
+
+# Create the output dir and a blank PULP_MANIFEST file
+mkdir "${output_dir}"
+touch "${output_dir}/PULP_MANIFEST"
+
+# Create the pseudo ISO files and update the PULP_MANIFEST with the generated
+# file information
+for i in {1..3}; do
+    output="${output_dir}/${i}.iso"
+    dd if=/dev/urandom of="${output}" bs="${i}M" count=1
+    line=${i}.iso,"$(sha256sum "${output}" | awk '{ print $1 }')","$(stat -c '%s' "${output}")"
+    echo "${line}" >> "${output_dir}/PULP_MANIFEST"
+done


### PR DESCRIPTION
File fixture is a repository where Pulp will publish the files. On Pulp
2 it is imported by the iso command but it does not mean that the files
should be a real ISO, it can be any file type. On Pulp 3 it will be
renamed to file and that is why this is called file fixtures.

A valid file fixture repository must have the fixtures files and the
PULP_MANIFEST file, the latter is a CSV file where each line is the file
path relative to the fixtures URL, the sha256sum of the file and the
size, in bytes, of the file.

Also add the file-mixed fixture which will generate a file fixture with
valid and invalid entries on the PULP_MANIFEST file.