### PR TITLE
Add puppet fixtures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ help:
 	@echo "  fixtures/file-mixed"
 	@echo "                  to create File fixtures with some not available"
 	@echo "                  files on the PULP_MANIFEST"
+	@echo "  fixtures/puppet to create a dummy Puppet module"
 	@echo "  fixtures/python-pulp"
 	@echo "                  to create a Pulp Python repository"
 	@echo "  fixtures/python-pypi [base_url=...]"
@@ -86,6 +87,7 @@ fixtures: fixtures/docker \
 	fixtures/drpm-unsigned \
 	fixtures/file \
 	fixtures/file-mixed \
+	fixtures/puppet \
 	fixtures/python \
 	fixtures/python-pulp \
 	fixtures/python-pypi \
@@ -131,6 +133,9 @@ fixtures/file-mixed:
 	file/gen-fixtures.sh $@
 	echo missing-1.iso,4a36e4eede4a61fd547040b53b1656b6dd489bd5bc4c0dd5fe55892dcf1669e8,1048576 >> $@/PULP_MANIFEST
 	echo missing-2.iso,ab6d91d4956d1a009bd6d03b3591f95aaae83b36907f77dd1ac71c400715b901,2097152 >> $@/PULP_MANIFEST
+
+fixtures/puppet:
+	puppet/gen-module.sh $@
 
 fixtures/python: fixtures/python-pulp
 	$(warning The `fixtures/python` target is deprecated. Use `fixtures/python-pulp` instead.)

--- a/README.rst
+++ b/README.rst
@@ -50,6 +50,9 @@ See ``make help``.
 ``fixtures/drpm-unsigned``
     The ``createrepo`` and ``makedeltarpm`` executables must be available.
 
+``fixtures/puppet``
+    The ``puppet`` executable must be available.
+
 ``fixtures/python-pulp``
     No exotic dependencies are needed.
 

--- a/puppet/gen-module.sh
+++ b/puppet/gen-module.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+#
+# Generate a Puppet module.
+#
+set -euo pipefail
+
+# See: http://mywiki.wooledge.org/BashFAQ/028
+readonly script_name='gen-module.sh'
+
+# Print usage instructions to stdout.
+show_help() {
+fmt <<EOF
+Usage: $script_name <output-dir>
+
+Generate a puppet module and place it in <output-dir>. <output-dir> need not
+exist, but all parent directories must exist.
+EOF
+}
+
+# Fetch arguments from user.
+if [ "$#" -lt 1 ]; then
+    echo 1>&2 'Error: Too few arguments received.'
+    echo 1>&2
+    show_help 1>&2
+    exit 1
+elif [ "$#" -gt 1 ]; then
+    echo 1>&2 'Error: Too many arguments received.'
+    echo 1>&2
+    show_help 1>&2
+    exit 1
+fi
+output_dir="$(realpath "$1")"
+module_name=pulpqe-dummypuppet  # we can parameterize this if need be
+
+# Create a workspace, and schedule it for deletion.
+cleanup() { if [ -n "${temp_dir:-}" ]; then rm -rf "${temp_dir}"; fi }
+trap cleanup EXIT  # bash pseudo signal
+trap 'cleanup ; trap - SIGINT ; kill -s SIGINT $$' SIGINT
+trap 'cleanup ; trap - SIGTERM ; kill -s SIGTERM $$' SIGTERM
+temp_dir="$(mktemp --directory)"
+
+(
+    cd "$temp_dir"
+    puppet module generate --skip-interview "${module_name}"
+    tar -czf "${module_name}.tar.gz" "${module_name#*-}"
+)
+install -Dm644 "${temp_dir}/${module_name}.tar.gz" \
+    "${output_dir}/${module_name}.tar.gz"


### PR DESCRIPTION
Add a new make target, `fixtures/puppet`, which generates a dummy Puppet
module. The new make target depends on the ``puppet`` executable.

Fix: https://github.com/PulpQE/pulp-fixtures/issues/31