### PR TITLE
Add target to create RPM with vendor data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,7 @@ fixtures: fixtures/docker \
 	fixtures/rpm-updated-updateinfo \
 	fixtures/rpm-with-non-ascii \
 	fixtures/rpm-with-non-utf-8 \
+	fixtures/rpm-with-vendor \
 	fixtures/rpm-with-pulp-distribution \
 	fixtures/srpm \
 	fixtures/srpm-signed \
@@ -223,6 +224,9 @@ fixtures/rpm-with-non-ascii:
 	rpm/gen-rpm.sh $@ "rpm/assets-specs/$$(basename $@).spec"
 
 fixtures/rpm-with-non-utf-8:
+	rpm/gen-rpm.sh $@ "rpm/assets-specs/$$(basename $@).spec"
+
+fixtures/rpm-with-vendor:
 	rpm/gen-rpm.sh $@ "rpm/assets-specs/$$(basename $@).spec"
 
 fixtures/rpm-with-pulp-distribution:

--- a/README.rst
+++ b/README.rst
@@ -138,6 +138,9 @@ See ``make help``.
 ``fixtures/rpm-with-non-utf-8``
     The ``fedpkg`` executable must be available.
 
+``fixtures/rpm-with-vendor``
+    The ``fedpkg`` executable must be available.
+
 ``fixtures/rpm-with-pulp-distribution``
     See ``fixtures/rpm-unsigned``.
 

--- a/rpm/assets-specs/rpm-with-vendor.spec
+++ b/rpm/assets-specs/rpm-with-vendor.spec
@@ -1,0 +1,22 @@
+Name:      rpm-with-vendor
+Version:   1
+Release:   1%{?dist}
+Summary:   An RPM file with a vendor
+License:   Public Domain
+URL:       https://github.com/PulpQE/pulp-fixtures
+BuildArch: noarch
+Vendor:    Pulp Fixtures
+
+%description
+This RPM has a vendor
+
+%prep
+
+%build
+
+%install
+
+%files
+
+%changelog
+


### PR DESCRIPTION
Closes #54 

I ran this make target and served it up with `python -m http.server`. I was able to download it and install it with `rpm`.

What do you think?

```sh
$ rpm -qip rpm-with-vendor-1-1.fc25.noarch.rpm 

Name        : rpm-with-vendor
Version     : 1
Release     : 1.fc25
Architecture: noarch
Install Date: (not installed)
Group       : Unspecified
Size        : 0
License     : Public Domain
Signature   : (none)
Source RPM  : rpm-with-vendor-1-1.fc25.src.rpm
Build Date  : Fri 07 Jul 2017 12:03:13 PM EDT
Build Host  : aardvark
Relocations : (not relocatable)
Vendor      : Pulp Fixtures
URL         : https://github.com/PulpQE/pulp-fixtures
Summary     : An RPM file with a vendor
Description :
This RPM has a vendor
```
(Yes, my VM is named aardvark)