### PR TITLE
Add script to generate ostree fixtures.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ help:
 	@echo "  fixtures/file-mixed"
 	@echo "                  to create File fixtures with some not available"
 	@echo "                  files on the PULP_MANIFEST"
+	@echo "  fixtures/ostree to create a OSTree ostree repositories"
 	@echo "  fixtures/puppet to create a dummy Puppet module"
 	@echo "  fixtures/python-pulp"
 	@echo "                  to create a Pulp Python repository"
@@ -143,6 +144,9 @@ fixtures/file-mixed:
 	file/gen-fixtures.sh $@
 	echo missing-1.iso,4a36e4eede4a61fd547040b53b1656b6dd489bd5bc4c0dd5fe55892dcf1669e8,1048576 >> $@/PULP_MANIFEST
 	echo missing-2.iso,ab6d91d4956d1a009bd6d03b3591f95aaae83b36907f77dd1ac71c400715b901,2097152 >> $@/PULP_MANIFEST
+
+fixtures/ostree:
+	ostree/gen-fixtures.sh $@/small
 
 fixtures/puppet:
 	puppet/gen-module.sh $@

--- a/README.rst
+++ b/README.rst
@@ -65,6 +65,9 @@ See ``make help``.
 ``fixtures/puppet``
     The ``puppet`` executable must be available.
 
+``fixtures/ostree``
+    The ``ostree`` executable must be available.
+
 ``fixtures/python-pulp``
     No exotic dependencies are needed.
 

--- a/ostree/gen-fixtures.sh
+++ b/ostree/gen-fixtures.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+DIR=""
+TREE=""
+USAGE="
+Usage: gen-fixtures.sh <output-dir>
+
+Generate an OSTree repository with (2) branches:
+ - rawhide
+ - stable
+
+Each branch will have (3) commits for versions:
+ - 1.0
+ - 1.1
+ - 1.2
+
+The OSTree repository will be created in <output-dir>.
+The directory will be be created.
+"
+
+show_help()
+{
+  echo "${USAGE}"
+}
+
+_mkdir()
+{
+  if [ -e "${DIR}" ]; then
+    if [ ! -z "$(ls -A "${DIR}")" ]; then
+      echo 1>&2 ""
+      echo 1>&2 "${DIR} must be empty."
+      echo 1>&2 ""
+      exit 1
+    fi
+  else
+    mkdir -p "${DIR}"
+  fi
+}
+
+gen_tree()
+{
+  # The tree used for the ostree commits must be a directory
+  # containing at least (1) file.  Using this script for convenience.
+  TREE=$(mktemp -d /tmp/tree.XXXXX)
+  touch "${TREE}/fake.img"
+}
+
+gen_repository()
+{
+  ostree init --repo="${DIR}" --mode=archive-z2
+  # branch: rawhide
+  ostree commit --repo="${DIR}" -b rawhide --add-metadata-string=version=1.1 "${TREE}"
+  ostree commit --repo="${DIR}" -b rawhide --add-metadata-string=version=1.2 "${TREE}"
+  ostree commit --repo="${DIR}" -b rawhide --add-metadata-string=version=1.3 "${TREE}"
+  # branch: stable
+  ostree commit --repo="${DIR}" -b stable --add-metadata-string=version=1.1 "${TREE}"
+  ostree commit --repo="${DIR}" -b stable --add-metadata-string=version=1.2 "${TREE}"
+  ostree commit --repo="${DIR}" -b stable --add-metadata-string=version=1.3 "${TREE}"
+  # summary
+  ostree summary -u --repo="${DIR}"
+}
+
+clean()
+{
+  if [ -d "${TREE}" ]; then
+    rm -rf "${TREE}"
+  fi
+}
+
+
+if [ "$#" -ne "1" ]; then
+  show_help
+  exit 1
+fi
+
+DIR="$1"
+
+trap clean EXIT
+
+_mkdir
+gen_tree
+gen_repository
+clean
+echo "Created repository in: ${DIR}"
+


### PR DESCRIPTION
Add script to generate ostree fixtures.  Specifically a small repository in `fixtures/ostree/small` used by some of the smash tests.