### PR TITLE
Add ability to create an RPM and repo metadata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,9 @@ help:
 	@echo "  fixtures/rpm-with-pulp-distribution"
 	@echo "                  to create an RPM repository with extra files and"
 	@echo "                  a PULP_DISTRIBUTION.xml file."
+	@echo "  fixtures/rpm-with-vendor"
+	@echo "                  to create an RPM repository with an RPM that has a"
+	@echo "                  vendor"
 	@echo "  fixtures/srpm-signed"
 	@echo "                  to create SRPM fixture data with signed packages"
 	@echo "  fixtures/srpm-unsigned"
@@ -231,7 +234,7 @@ fixtures/rpm-with-non-utf-8:
 	rpm/gen-rpm.sh $@ "rpm/assets-specs/$$(basename $@).spec"
 
 fixtures/rpm-with-vendor:
-	rpm/gen-rpm.sh $@ "rpm/assets-specs/$$(basename $@).spec"
+	rpm/gen-rpm-and-repo.sh $@ "rpm/assets-specs/$$(basename $@).spec"
 
 fixtures/rpm-with-pulp-distribution:
 	rpm/gen-fixtures.sh $@ rpm/assets

--- a/README.rst
+++ b/README.rst
@@ -142,7 +142,7 @@ See ``make help``.
     The ``fedpkg`` executable must be available.
 
 ``fixtures/rpm-with-vendor``
-    The ``fedpkg`` executable must be available.
+    The ``fedpkg`` and ``createrepo`` executables must be available.
 
 ``fixtures/rpm-with-pulp-distribution``
     See ``fixtures/rpm-unsigned``.

--- a/rpm/gen-rpm-and-repo.sh
+++ b/rpm/gen-rpm-and-repo.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+#
+# Generate an RPM and a repository for that RPM.
+#
+set -euo pipefail
+
+# Assume this script has been called from the Pulp Fixtures makefile.
+source ./rpm/common.sh
+
+# See: http://mywiki.wooledge.org/BashFAQ/028
+readonly script_name='gen-rpm-and-repo.sh'
+
+# Print usage instructions to stdout.
+show_help() {
+fmt <<EOF
+Usage: ${script_name} <output-dir> <spec-file>
+
+Generate an RPM from the <spec-file>. Generate metadata referencing that RPM.
+Move the resulting repository to <output-dir>. <output-dir> need not exist.
+EOF
+}
+
+# Transform $@. $temp is needed. If omitted, non-zero exit codes are ignored.
+check_getopt
+temp=$(getopt --name "${script_name}" -o '+' -- "$@")
+eval set -- "${temp}"
+unset temp
+
+# Read arguments. (getopt inserts -- even when no arguments are passed.)
+if [ "${#@}" -eq 1 ]; then
+    show_help
+    exit 0
+fi
+while true; do
+    case "$1" in
+        --) shift; break;;
+        *) echo "Internal error! Encountered unexpected argument: $1"; exit 1;;
+    esac
+done
+output_dir="$(realpath "$1")"
+spec_file="$(realpath --canonicalize-existing "$2")"
+shift 2
+
+# Create a workspace, and schedule it for deletion.
+cleanup() { if [ -n "${working_dir:-}" ]; then rm -rf "${working_dir}"; fi }
+trap cleanup EXIT  # bash pseudo signal
+trap 'cleanup ; trap - SIGINT ; kill -s SIGINT $$' SIGINT
+trap 'cleanup ; trap - SIGTERM ; kill -s SIGTERM $$' SIGTERM
+working_dir="$(mktemp --directory)"
+
+# Generate an RPM, and generate repository metadata for it.
+./rpm/gen-rpm.sh "${working_dir}" "${spec_file}"
+createrepo --checksum sha256 "${working_dir}"
+
+# Copy repository to destination.
+#
+# The working directory is copied rather than moved to prevent cleanup() from
+# reaping an innocent directory. --no-preserve is used because `mktemp -d`
+# creates directories with a mode of 700, and a mode of 755 (or whatever the
+# umask dictates) is desired.
+cp -r --no-preserve=mode --reflink=auto "${working_dir}" "${output_dir}"


### PR DESCRIPTION
Add a script, `gen-rpm-and-repo.sh`, that both creates an RPM from a
spec file and generates RPM repository metadata for that RPM. Let the
`fixtures/rpm-with-vendor` make target make use of it.

Fix: https://github.com/PulpQE/pulp-fixtures/issues/58