### PR TITLE
Target a consistent platform when generating repos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,11 +83,8 @@ clean:
 	rm -rf fixtures/* gnupghome
 
 # xargs communicates return values better than find's `-exec` argument.
-# --external-sources is used because at least one script sources
-# /etc/os-release. Passing /etc/os-release to shellcheck's argument list
-# produces unnecessary warnings.
 lint:
-	find . -name '*.sh' -print0 | xargs -0 shellcheck --external-sources
+	find . -name '*.sh' -print0 | xargs -0 shellcheck
 
 all: fixtures
 	$(warning The `all` target is deprecated. Use `fixtures` instead.)

--- a/rpm/gen-rpm.sh
+++ b/rpm/gen-rpm.sh
@@ -51,10 +51,9 @@ working_dir="$(mktemp --directory)"
 # Copy the spec file into the workspace and generate an RPM.
 cp "${spec_file}" "${working_dir}/"
 (
-    source /etc/os-release
     cd "${working_dir}"
-    fedpkg --release "f${VERSION_ID}" local
+    fedpkg --release f25 local
     install -Dm644 \
-        "noarch/$(basename "${spec_file%.spec}")-1-1.fc${VERSION_ID}.noarch.rpm" \
-        "${output_dir}/$(basename "${spec_file%.spec}")-1-1.fc${VERSION_ID}.noarch.rpm"
+        "noarch/$(basename "${spec_file%.spec}")-1-1.fc25.noarch.rpm" \
+        "${output_dir}/$(basename "${spec_file%.spec}")-1-1.fc25.noarch.rpm"
 )


### PR DESCRIPTION
`fedpkg local` lets one create a "local test rpmbuild binary" from a
spec file. Several fixtures targets use this command, including
`fixtures/rpm-with-non-ascii`.

The `--release` lets one target a specific distribution, such as "f25."
Currently, this flag is passed an option depending on the distribution
on which packages are being generated. For example, if fixtures are
being generated on Fedora 25, then "f25" is passed, and if fixtures are
being generated on Fedora 26, then "f26" is passed. This behaviour seems
like a recipe for breakage: if we ever change what kind of VMs are used
to generate fixtures, then different RPMs will be generated, and clients
that depend on the fixtures may break.

Hard-code a target platform into the RPM generation script. This allows
the fixtures to be generated on a variety of distributions, while
producing the same result. The downside of this change is that the RPM
fixtures repository will require some maintenance over time, as the
target platform will eventually become extremely out of date. But the
benefit seems to greatly outweigh the downside.