### PR TITLE
Unify RPM name parsing functions

### DIFF
--- a/rpm/common.sh
+++ b/rpm/common.sh
@@ -20,3 +20,68 @@ EOF
         exit 1
     fi
 }
+
+# Given the path to an RPM, return its epoch.
+#
+# Examples:
+#
+#   'assets/1!baby-walrus-5.21-1.noarch.rpm' → 1
+#   'assets/baby-walrus-5.21-1.noarch.rpm' → 0
+get_rpm_epoch() {
+    local filename
+    filename="$(basename "${1}")"
+    case "${filename}" in
+        *'!'*)
+            echo "${filename%\!*}"
+            ;;
+        *)
+            echo 0
+            ;;
+    esac
+}
+
+# Given the path to an RPM, return its name.
+#
+# Example: 'assets/1!baby-walrus-5.21-1.noarch.rpm' → baby-walrus
+get_rpm_name() {
+    local filename
+    filename="$(basename "${1}")"
+    filename="${filename#*\!}"  # strip epoch
+    filename="${filename%-*}"  # strip release and architecture
+    filename="${filename%-*}"  # strip version
+    echo "${filename}"
+}
+
+# Given the path to an RPM, return its version.
+#
+# Example: 'assets/1!baby-walrus-5.21-1.noarch.rpm' → 5.21
+get_rpm_version() {
+    local filename
+    filename="$(basename "${1}")"
+    filename="${filename#*\!}"  # strip epoch
+    filename="${filename%-*}"  # strip release and architecture
+    filename="${filename##*-}"  # strip name
+    echo "${filename}"
+}
+
+# Given the path to an RPM, return its release.
+#
+# Example: 'assets/1!baby-walrus-5.21-1.noarch.rpm' → 1
+get_rpm_release() {
+    local filename
+    filename="$(basename "${1}")"
+    filename="${filename##*-}"  # strip epoch, name and version
+    filename="${filename%%.*}"  # strip architecture
+    echo "${filename}"
+}
+
+# Given the path to an RPM, return its architecture.
+#
+# Example: 'assets/1!baby-walrus-5.21-1.noarch.rpm' → noarch.rpm
+get_rpm_architecture() {
+    local filename
+    filename="$(basename "${1}")"
+    filename="${filename##*-}"  # strip epoch, name and version
+    filename="${filename#*.}"  # strip release
+    echo "${filename}"
+}

--- a/rpm/gen-erratum.sh
+++ b/rpm/gen-erratum.sh
@@ -5,6 +5,9 @@
 #
 set -euo pipefail
 
+# Assume this script has been called from the Pulp Fixtures makefile.
+source ./rpm/common.sh
+
 #------------------------------------------------------------------------------
 # Helper Functions
 #------------------------------------------------------------------------------
@@ -34,7 +37,7 @@ EOF
 # Given an RPM filename, echo a JSON description of the RPM.
 make_erratum_package() {
 cat <<EOF
-"arch": "$(get_rpm_arch "${1}")",
+"arch": "$(get_rpm_architecture "${1}")",
 "epoch": "$(get_rpm_epoch "${1}")",
 "filename": "$(basename "${1}")",
 "name": "$(get_rpm_name "${1}")",
@@ -48,63 +51,6 @@ cat <<EOF
 ],
 "version": "$(get_rpm_version "${1}")"
 EOF
-}
-
-# Given a path to an RPM package, echo the package epoch.
-#
-# e.g. assets/walrus-5.21-1.noarch.rpm → 0
-get_rpm_epoch() {
-    local filename
-    filename="$(basename "${1}")"
-    # If an epoch is listed, return it. Otherwise, assume an epoch of 0.
-    case "${filename}" in
-        *'!'*)
-            echo "${filename#\!*}"
-            ;;
-        *)
-            echo 0
-            ;;
-    esac
-}
-
-# Given a path to an RPM package, echo the package name.
-#
-# e.g. assets/walrus-5.21-1.noarch.rpm → walrus
-get_rpm_name() {
-    local filename parts
-    filename="$(basename "${1}")"
-    IFS=$'\n' parts=($(echo "${filename}" | tr - "\n"))
-    echo "${parts[0]#*\!}"  # strip epoch
-}
-
-# Given a path to an RPM package, echo the package version.
-#
-# e.g. assets/walrus-5.21-1.noarch.rpm → 5.21
-get_rpm_version() {
-    local filename parts
-    filename="$(basename "${1}")"
-    IFS=$'\n' parts=($(echo "${filename}" | tr - "\n"))
-    echo "${parts[1]}"
-}
-
-# Given a path to an RPM package, echo the package release.
-#
-# e.g. assets/walrus-5.21-1.noarch.rpm → 1
-get_rpm_release() {
-    local filename parts
-    filename="$(basename "${1}")"
-    IFS=$'\n' parts=($(echo "${filename}" | tr - "\n"))
-    echo "${parts[2]%%.*}"
-}
-
-# Given a path to an RPM package, echo the package arch.
-#
-# e.g. assets/walrus-5.21-1.noarch.rpm → noarch
-get_rpm_arch() {
-    local filename parts
-    filename="$(basename "${1}")"
-    IFS=$'\n' parts=($(echo "${filename}" | tr . "\n"))
-    echo "${parts[-2]}"
 }
 
 # Given a path to a file, echo the file's sha256 checksum.

--- a/rpm/gen-fixtures-delta.sh
+++ b/rpm/gen-fixtures-delta.sh
@@ -34,55 +34,6 @@ Options:
 EOF
 }
 
-# Given a path to an RPM package, echo the package name.
-#
-# e.g. assets/walrus-baby-5.21-1.noarch.rpm → walrus-baby
-get_rpm_name() {
-    local filename parts end
-    filename="$(basename "${1}")"
-    IFS=$'\n' parts=($(echo "${filename}" | tr - "\n"))
-    end=$(( ${#parts[@]} - 2 ))
-    for ((i=0; i< end ; i++)); do
-        rpm_name+="${parts[i]}"-
-    done
-    rpm_name="${rpm_name::-1}"
-    echo "${rpm_name#*\!}"  # strip epoch
-}
-
-# Given a path to an RPM package, echo the package version.
-#
-# e.g. assets/walrus-5.21-1.noarch.rpm → 5.21
-get_rpm_version() {
-    local filename parts
-    filename="$(basename "${1}")"
-    IFS=$'\n' parts=($(echo "${filename}" | tr - "\n"))
-    echo "${parts[-2]}"
-}
-
-# Given a pathto an RPM package, echo the package release.
-#
-# e.g. assets/yum-cron-3.4.3-10.fc16.noarch.rpm  → 10.fc16
-get_rpm_release() {
-    local filename parts
-    filename="$(basename "${1}")"
-    IFS=$'\n' parts=($(echo "${filename}" | tr - "\n"))
-    last_part="${parts[-1]}"
-    pattern="${2}.rpm"
-
-    release="${last_part%.$pattern}"
-    echo "${release}"
-}
-
-# Given a path to an RPM package, echo the package arch.
-#
-# e.g. assets/walrus-5.21-1.noarch.rpm → noarch
-get_rpm_arch() {
-    local filename parts
-    filename="$(basename "${1}")"
-    IFS=$'\n' parts=($(echo "${filename}" | tr . "\n"))
-    echo "${parts[-2]}"
-}
-
 #------------------------------------------------------------------------------
 # Business Logic
 #------------------------------------------------------------------------------
@@ -143,8 +94,8 @@ EOF
         exit 1
     fi
 
-    arch_1="$(get_rpm_arch "${rpm_1}")"
-    arch_2="$(get_rpm_arch "${rpm_2}")"
+    arch_1="$(get_rpm_architecture "${rpm_1}")"
+    arch_2="$(get_rpm_architecture "${rpm_2}")"
     if [ "${arch_1}" != "${arch_2}" ]; then
         fmt 1>&2 <<EOF
 Error: Old and new packages must have the same architecture, but are different.
@@ -158,7 +109,7 @@ EOF
     rel_1="$(get_rpm_release "${rpm_1}" "${arch_1}")"
     rel_2="$(get_rpm_release "${rpm_2}" "${arch_2}")"
     makedeltarpm "${rpm_1}" "${rpm_2}" \
-        "${working_dir}/drpms/${name_2}-${ver_1}-${rel_1}_${ver_2}-${rel_2}.${arch_2}.drpm"
+        "${working_dir}/drpms/${name_1}-${ver_1}-${rel_1}_${ver_2}-${rel_2}.${arch_1%.rpm}.drpm"
 done
 
 # Sign DRPMs and generate repository metadata.


### PR DESCRIPTION
Add several RPM name parsing functions to `rpm/common.sh`:

* `get_rpm_epoch`
* `get_rpm_name`
* `get_rpm_version`
* `get_rpm_release`
* `get_rpm_architecture`

Let `rpm/gen-erratum.sh` and `rpm/gen-fixtures-delta.sh` use these
functions instead of the name parsing functions that are defined in
those scripts. Note that the functions in those scripts are known to
have bugs. For example, the `get_rpm_name` function in
`rpm/gen-erratum.sh` doesn't handle RPMs whose names contain dashes,
such as `baby-walrus-5.21-1.noarch.rpm`.

Fix: https://github.com/PulpQE/pulp-fixtures/issues/23