### PR TITLE
Declare the character encoding of shell scripts

### DIFF
--- a/docker/gen-fixtures.sh
+++ b/docker/gen-fixtures.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env sh
+# coding=utf-8
 #
 # Use `docker save` to create a tarball that can be uploaded to a Pulp Docker
 # repository. Docker must be installed and available for use.

--- a/file/gen-fixtures.sh
+++ b/file/gen-fixtures.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# coding=utf-8
 #
 # Generate a file repository.
 #

--- a/ostree/gen-fixtures.sh
+++ b/ostree/gen-fixtures.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# coding=utf-8
 
 set -euo pipefail
 

--- a/puppet/gen-module.sh
+++ b/puppet/gen-module.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# coding=utf-8
 #
 # Generate a Puppet module.
 #

--- a/python/gen-pypi-repo.sh
+++ b/python/gen-pypi-repo.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# coding=utf-8
 #
 # Generate a PyPI-compatible Python repository.
 #

--- a/rpm/common.sh
+++ b/rpm/common.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# coding=utf-8
 #
 # Re-usable functions for use by the other RPM-generation scripts.
 

--- a/rpm/gen-erratum.sh
+++ b/rpm/gen-erratum.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# coding=utf-8
 #
 # Generate an erratum that can be uploaded to a Pulp RPM repository.
 #

--- a/rpm/gen-fixtures-delta.sh
+++ b/rpm/gen-fixtures-delta.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# coding=utf-8
 #
 # Generate RPM repository with DRPM fixture data.
 #

--- a/rpm/gen-fixtures.sh
+++ b/rpm/gen-fixtures.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# coding=utf-8
 #
 # Generate an RPM repository.
 #

--- a/rpm/gen-patched-fixtures.sh
+++ b/rpm/gen-patched-fixtures.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# coding=utf-8
 #
 # WARNING: Calling this script by hand is not recommended. It should instead be
 # called by the pulp-fixtures make file. That's because this script doesn't

--- a/rpm/gen-rpm-and-repo.sh
+++ b/rpm/gen-rpm-and-repo.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# coding=utf-8
 #
 # Generate an RPM and a repository for that RPM.
 #

--- a/rpm/gen-rpm.sh
+++ b/rpm/gen-rpm.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# coding=utf-8
 #
 # Generate an RPM.
 #


### PR DESCRIPTION
Declare every shell script as having a character encoding of utf-8. This
change has no effect on systems whose locale already has a codeset of
utf-8. For example, a system whose `LANG` is set to `en_US.UTF-8` or
`ru_RU.UTF-8` already treats text files as having a character encoding
of utf-8 by default. However, this change ensures that shell scripts are
correctly decoded on systems with a different locale set. For example, a
system whose `LANG` is set to `en_US` or `ru_RU.KOI8-R` will now
correctly decode these shell scrips.