### PR TITLE
Add new fixture, fixtures/rpm-invalid-rpm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,8 @@ help:
 	@echo "  fixtures/rpm-incomplete-other"
 	@echo "                  to create an RPM repository with an incomplete"
 	@echo "                  other.xml"
+	@echo "  fixtures/rpm-invalid-rpm"
+	@echo "                  to create an invalid RPM"
 	@echo "  fixtures/rpm-invalid-updateinfo"
 	@echo "                  to create RPM fixtures with updated updateinfo.xml"
 	@echo "  fixtures/rpm-mirrorlist-bad [base_url=...]"
@@ -104,6 +106,7 @@ fixtures: fixtures/docker \
 	fixtures/rpm-erratum \
 	fixtures/rpm-incomplete-filelists \
 	fixtures/rpm-incomplete-other \
+	fixtures/rpm-invalid-rpm \
 	fixtures/rpm-invalid-updateinfo \
 	fixtures/rpm-mirrorlist-bad \
 	fixtures/rpm-mirrorlist-good \
@@ -182,6 +185,9 @@ fixtures/rpm-incomplete-other:
 	gunzip $@/repodata/*-other.xml.gz
 	sed -i -e '/<package /,/<\/package>/d' $@/repodata/*-other.xml
 	gzip $@/repodata/*-other.xml
+
+fixtures/rpm-invalid-rpm:
+	rpm/gen-invalid-rpm.sh $@
 
 fixtures/rpm-invalid-updateinfo:
 	rpm/gen-patched-fixtures.sh $@ rpm/invalid-updateinfo.patch

--- a/README.rst
+++ b/README.rst
@@ -94,6 +94,9 @@ See ``make help``.
 ``fixtures/rpm-incomplete-other``
     See ``fixtures/rpm-unsigned``.
 
+``fixtures/rpm-invalid-rpm``
+    No exotic dependencies are needed.
+
 ``fixtures/rpm-invalid-updateinfo``
     See ``fixtures/rpm-unsigned``.
 

--- a/rpm/gen-invalid-rpm.sh
+++ b/rpm/gen-invalid-rpm.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# coding=utf-8
+#
+# Generate an invalid RPM.
+#
+set -euo pipefail
+
+# Assume this script has been called from the Pulp Fixtures makefile.
+source ./rpm/common.sh
+
+# See: http://mywiki.wooledge.org/BashFAQ/028
+readonly script_name='gen-invalid-rpm.sh'
+
+# Print usage instructions to stdout.
+show_help() {
+fmt <<EOF
+Usage: ${script_name} <output-dir>
+
+Generate an invalid RPM, and place it into <output-dir>. <output-dir> need not
+exist.
+EOF
+}
+
+# Transform $@. $temp is needed. If omitted, non-zero exit codes are ignored.
+check_getopt
+temp=$(getopt --name "${script_name}" -o '+' -- "$@")
+eval set -- "${temp}"
+unset temp
+
+# Read arguments. (getopt inserts -- even when no arguments are passed.)
+if [ "${#@}" -eq 1 ]; then
+    show_help
+    exit 0
+fi
+while true; do
+    case "$1" in
+        --) shift; break;;
+        *) echo "Internal error! Encountered unexpected argument: $1"; exit 1;;
+    esac
+done
+output_dir="$(realpath "$1")"
+shift
+
+# Create a temporary file.
+cleanup() { if [ -n "${temp_file:-}" ]; then rm -f "${temp_file}"; fi }
+trap cleanup EXIT  # bash pseudo signal
+trap 'cleanup ; trap - SIGINT ; kill -s SIGINT $$' SIGINT
+trap 'cleanup ; trap - SIGTERM ; kill -s SIGTERM $$' SIGTERM
+temp_file="$(mktemp)"
+
+# Generate an invalid RPM, and copy it to the output directory.
+dd if=/dev/urandom of="${temp_file}" bs=1KB count=1
+install -Dm644 "${temp_file}" "${output_dir}/invalid.rpm"


### PR DESCRIPTION
Add a new make target, `fixtures/rpm-invalid-rpm`. This make target
generates an invalid RPM and places it into the named directory.

Fix: https://github.com/PulpQE/pulp-fixtures/issues/65