### PR TITLE
Add fixture with large updateinfo.xml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,8 @@ help:
 	@echo "                  to create an invalid RPM"
 	@echo "  fixtures/rpm-invalid-updateinfo"
 	@echo "                  to create RPM fixtures with updated updateinfo.xml"
+	@echo "  fixtures/long-updateinfo"
+	@echo "                  to create an RPM repo with an enormous updateinfo.xml"
 	@echo "  fixtures/rpm-mirrorlist-bad [base_url=...]"
 	@echo "  fixtures/rpm-mirrorlist-good [base_url=...]"
 	@echo "  fixtures/rpm-mirrorlist-mixed [base_url=...]"
@@ -111,6 +113,7 @@ fixtures: fixtures/docker \
 	fixtures/rpm-incomplete-other \
 	fixtures/rpm-invalid-rpm \
 	fixtures/rpm-invalid-updateinfo \
+	fixtures/rpm-long-updateinfo \
 	fixtures/rpm-mirrorlist-bad \
 	fixtures/rpm-mirrorlist-good \
 	fixtures/rpm-mirrorlist-mixed \
@@ -197,6 +200,9 @@ fixtures/rpm-invalid-rpm:
 
 fixtures/rpm-invalid-updateinfo:
 	rpm/gen-patched-fixtures.sh $@ rpm/invalid-updateinfo.patch
+
+fixtures/rpm-long-updateinfo:
+	rpm/gen-long-updateinfo.sh $@
 
 fixtures/rpm-mirrorlist-bad:
 	echo $(base_url)/fixtures/rpm-unsignedd/ > $@

--- a/README.rst
+++ b/README.rst
@@ -103,6 +103,9 @@ See ``make help``.
 ``fixtures/rpm-invalid-updateinfo``
     See ``fixtures/rpm-unsigned``.
 
+``fixtures/rpm-long-updateinfo``
+    See ``fixtures/rpm-unsigned``.
+
 ``fixtures/rpm-mirrorlist-bad``
     No exotic dependencies are needed.
 

--- a/rpm/gen-long-updateinfo.sh
+++ b/rpm/gen-long-updateinfo.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# coding=utf-8
+#
+# WARNING: Calling this script by hand is not recommended. It should instead be
+# called by the pulp-fixtures make file. That's because this script doesn't
+# perform the same human-friendly input validation as `./gen-fixtures.sh`, and
+# it includes hard-coded relative paths.
+#
+# Usage:
+#
+#     gen-long-updateinfo.sh <output_dir>
+#
+# Behaviour:
+#
+# 1. Create a temporary directory.
+# 2. Copy assets into this directory.
+# 3. Overwrite assets_dir/updateinfo.xml.
+# 4. Call gen-fixtures.sh, and point it at our patched assets.
+# 5. Remove the temporary directory.
+#
+set -euo pipefail
+
+# Read arguments.
+output_dir="${1}"
+
+# Define a procedure for graceful termination.
+cleanup() {
+    if [ -n "${assets_dir:-}" ]; then
+        rm -rf "${assets_dir}"
+    fi
+}
+trap cleanup EXIT  # bash pseudo signal
+trap 'cleanup ; trap - SIGINT ; kill -s SIGINT $$' SIGINT
+trap 'cleanup ; trap - SIGTERM ; kill -s SIGTERM $$' SIGTERM
+
+# Generate patched assets.
+assets_dir="$(mktemp --directory)"
+cp -rt "${assets_dir}" rpm/assets/*
+
+cat > "${assets_dir}/updateinfo.xml" <<EOF
+<?xml version="1.0"?>
+<updates>
+<update from="errata@redhat.com" status="stable" type="security" version="1">
+  <id>RHEA-2012:0055</id>
+  <title>Sea_Erratum</title>
+  <release>1</release>
+  <issued date="2012-01-27 16:08:06"/>
+  <updated date="2012-01-27 16:08:06"/>
+  <description>Sea_Erratum</description>
+  <pkglist>
+    <collection short="">
+      <name>1</name>
+EOF
+for _ in {1..20000}; do
+cat >> "${assets_dir}/updateinfo.xml" <<EOF
+      <package arch="noarch" name="walrus" release="1" src="http://www.fedoraproject.org" version="5.21">
+        <filename>walrus-5.21-1.noarch.rpm</filename>
+      </package>
+      <package arch="noarch" name="penguin" release="1" src="http://www.fedoraproject.org" version="0.9.1">
+        <filename>penguin-0.9.1-1.noarch.rpm</filename>
+      </package>
+      <package arch="noarch" name="shark" release="1" src="http://www.fedoraproject.org" version="0.1">
+        <filename>shark-0.1-1.noarch.rpm</filename>
+      </package>
+EOF
+done
+cat >> "${assets_dir}/updateinfo.xml" <<EOF
+    </collection>
+  </pkglist>
+</update>
+</updates>
+EOF
+
+./rpm/gen-fixtures.sh "${output_dir}" "${assets_dir}"


### PR DESCRIPTION
Add the make target `fixtures/rpm-long-updateinfo`. This target creates
an RPM repository with an enormous updateinfo.xml file.

Fix: https://github.com/PulpQE/pulp-fixtures/issues/59