### PR TITLE
Improve array sorting code; require bash 4.4+

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,11 +20,10 @@ For exact usage instructions, clone this repository and run ``make help``.
 Dependencies
 ------------
 
-The make targets and fixture generation scripts do little more than call out to
-system executables and mangle the results. It's the user's responsibility to
-ensure the necessary executables are available and usable. Dependencies are
-listed below, according to make target. Common system executables like ``fmt``,
-``patch`` and ``realpath`` are omitted.
+Most make targets are implemented as bash scripts. Bash 4.4 or newer is
+required. In addition, exotic dependencies are listed below, according to make
+target. Common dependencies like ``fmt``, ``patch`` and ``realpath`` are
+omitted.
 
 Some RPM, SRPM and DRPM fixtures are signed with an OpenPGP-compatible keypair.
 See ``make help``.

--- a/rpm/gen-fixtures-delta.sh
+++ b/rpm/gen-fixtures-delta.sh
@@ -79,7 +79,7 @@ fi
 
 # Make DRPMs from RPMs.
 mkdir "${working_dir}/drpms"
-IFS=$'\n' rpms=($(sort <<<"${rpms[*]}"))  # sort files by name
+mapfile -t -d $'\0' rpms < <(printf '%s\0' "${rpms[@]}" | sort -z)  # sort rpms
 for (( i=0; i < num_rpms - 1; i++ )); do
     rpm_1="${rpms[i]}"
     rpm_2="${rpms[i+1]}"


### PR DESCRIPTION
Re-write the array sorting code in `rpm/gen-fixtures-delta.sh`. The new
code is better in two ways:

* It's more robust. Filenames can contain virtually any character. See:
  * http://git.savannah.gnu.org/cgit/bash.git/plain/NEWS (See the new
    features in bash 4.4, section 1 d.)
  * https://transnum.blogspot.com/2008/11/bashs-read-built-in-supports-0-as.html
  * https://stackoverflow.com/a/7442583 (See the comments.)
* It doesn't permanently alter $IFS. See:
  * https://github.com/koalaman/shellcheck/wiki/SC2207
  * https://stackoverflow.com/a/11789688

This change fixes the shellcheck warning mentioned above.

The new code takes advantage of features added in bash 4.4. As a result,
fixtures will now need to be generated on Fedora 26 or newer.