### PR TITLE
Modernize file generation script

### DIFF
--- a/file/gen-fixtures.sh
+++ b/file/gen-fixtures.sh
@@ -5,44 +5,79 @@
 #
 set -euo pipefail
 
+# Assume this script has been called from the Pulp Fixtures makefile.
+source ./rpm/common.sh
+
+# See: http://mywiki.wooledge.org/BashFAQ/028
+readonly script_name='gen-fixtures.sh'
+
 # Print usage instructions to stdout.
 show_help() {
 fmt <<EOF
 Usage: gen-fixtures.sh <output-dir>
 
-Generate a file repository with pseudo ISO files (generated with bytes from
-/dev/urandom) with different filesize. Then generate the PULP_MANIFEST file
-describring the generated files.
-
-Place the repository's contents into <output-dir>. <output-dir> need not exist,
+Generate several pseudo-random ISO files and a PULP_MANIFEST file describing
+them. Place them into a directory at <output-dir>. <output-dir> need not exist,
 but all parent directories must exist.
+
+Options:
+    --number <integer>
+        The number of ISO files to generate. Default: 3.
 EOF
 }
 
-# Fetch output_dir from user.
-if [ "$#" -lt 1 ]; then
-    echo 1>&2 'Error: Too few arguments received.'
-    echo 1>&2
-    show_help 1>&2
-    exit 1
-elif [ "$#" -gt 1 ]; then
-    echo 1>&2 'Error: Too many arguments received.'
-    echo 1>&2
-    show_help 1>&2
-    exit 1
-else
-    output_dir="$(realpath --canonicalize-missing "${1}")"
-fi
+# Transform $@. $temp is needed. If omitted, non-zero exit codes are ignored.
+check_getopt
+temp=$(getopt \
+    --options '' \
+    --longoptions number:, \
+    --name "$script_name" \
+    -- "$@")
+eval set -- "$temp"
+unset temp
 
-# Create the output dir and a blank PULP_MANIFEST file
-mkdir "${output_dir}"
-touch "${output_dir}/PULP_MANIFEST"
+# Read arguments. (getopt inserts -- even when no arguments are passed.)
+if [ "${#@}" -eq 1 ]; then
+    show_help
+    exit 0
+fi
+while true; do
+    case "$1" in
+        --number) number="$2"; shift 2;;
+        --) shift; break;;
+        *) echo "Internal error! Encountered unexpected argument: $1"; exit 1;;
+    esac
+done
+output_dir="$(realpath "$1")"
+number="${number:-3}"
+shift
+
+# Create a workspace, and schedule it for deletion.
+cleanup() { if [ -n "${working_dir:-}" ]; then rm -rf "${working_dir}"; fi }
+trap cleanup EXIT  # bash pseudo signal
+trap 'cleanup ; trap - SIGINT ; kill -s SIGINT $$' SIGINT
+trap 'cleanup ; trap - SIGTERM ; kill -s SIGTERM $$' SIGTERM
+working_dir="$(mktemp --directory)"
 
 # Create the pseudo ISO files and update the PULP_MANIFEST with the generated
 # file information
-for i in {1..3}; do
-    output="${output_dir}/${i}.iso"
-    dd if=/dev/urandom of="${output}" bs="${i}M" count=1
-    line=${i}.iso,"$(sha256sum "${output}" | awk '{ print $1 }')","$(stat -c '%s' "${output}")"
-    echo "${line}" >> "${output_dir}/PULP_MANIFEST"
+for ((i=0; i<number; i++)); do
+    of="${working_dir}/$((i + 1))"
+    dd if=/dev/urandom of="${of}" bs=1K count=1
+    echo "$((i + 1)),$(sha256sum "${of}" | awk '{print $1}'),$(stat -c '%s' "${of}")" \
+    >> "${working_dir}/PULP_MANIFEST"
 done
+
+# Copy fixtures to $output_dir.
+#
+# A $working_dir is used to make fixture generation more atomic. If fixture
+# generation fails, this script (or the calling make target) can be run again
+# without worrying about cleanup work. $working_dir is copied rather than moved
+# to prevent cleanup() from reaping an innocent directory. --no-preserve is used
+# because `mktemp -d` creates directories with a mode of 700, and a mode of 755
+# (or whatever the umask dictates) is desired.
+if [ -d "${output_dir}" ]; then
+    cp -r --no-preserve=mode --reflink=auto "${working_dir}"/* "${output_dir}"
+else
+    cp -r --no-preserve=mode --reflink=auto "${working_dir}" "${output_dir}"
+fi


### PR DESCRIPTION
Do the following:

* Make fixture creation more atomic.
* Use getopt for argument parsing, along with the `check_getopt`
  function from `rpm/common.sh`.
* Add an optional `--number` argument to the script, which controls how
  many files should be generated.
* Generate much smaller files. There's no special reason to generate
  files several megabytes in size.