### PR TITLE
Add fixture to generate many files.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,8 @@ help:
 	@echo "        contents."
 	@echo "    fixtures/file-large"
 	@echo "        Create large file fixtures, with 10 file fixtures."
+	@echo "    fixtures/file-many"
+	@echo "        Create many file fixtures, with 250 file fixtures."
 	@echo "    fixtures/file-mixed"
 	@echo "        Create File fixtures with some not available files on the"
 	@echo "        PULP_MANIFEST."
@@ -108,6 +110,7 @@ fixtures: fixtures/docker \
 	fixtures/file \
 	fixtures/file2 \
 	fixtures/file-large\
+	fixtures/file-many\
 	fixtures/file-mixed \
 	fixtures/puppet \
 	fixtures/python \
@@ -160,6 +163,9 @@ fixtures/file2:
 
 fixtures/file-large:
 	file/gen-fixtures.sh $@ --number 10
+
+fixtures/file-many:
+	file/gen-fixtures.sh $@ --number 250
 
 fixtures/file-mixed:
 	file/gen-fixtures.sh $@

--- a/README.rst
+++ b/README.rst
@@ -64,6 +64,9 @@ See ``make help``.
 ``fixtures/file-large``
     No exotic dependencies are needed.
 
+``fixtures/file-many``
+    No exotic dependencies are needed.
+
 ``fixtures/file-mixed``
     See ``fixtures/file``.
 


### PR DESCRIPTION
Re-use most of tooling already in place to generate a fixutes with a
massive number of files.

Pulp 3 handles pagination. Right now, the default value of items per
page is 100.

This fixture will create 250 files, this one can be used to test the
pagination for Pulp 3.

Closes:#80