### PR TITLE
Split fixture for srpm and rpm with rich dependencies.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,9 +78,6 @@ help:
 	@echo "    fixtures/rpm-richnweak-deps"
 	@echo "        Create RPM fixture data with packages with regular,"
 	@echo "        weak and very weak dependencies."
-	@echo "    fixtures/rpm-richnweak-deps/srpms"
-	@echo "        Create SRPM fixture data with packages with regular,"
-	@echo "        weak and very weak dependencies."
 	@echo "    fixtures/rpm-signed"
 	@echo "        Create RPM fixture data with signed packages."
 	@echo "    fixtures/rpm-unsigned"
@@ -96,6 +93,9 @@ help:
 	@echo "        PULP_DISTRIBUTION.xml file."
 	@echo "    fixtures/rpm-with-vendor"
 	@echo "        Create an RPM repository with an RPM that has a vendor."
+	@echo "    fixtures/srpm-richnweak-deps"
+	@echo "        Create SRPM fixture data with packages with regular,"
+	@echo "        weak and very weak dependencies."
 	@echo "    fixtures/srpm-signed"
 	@echo "        Create SRPM fixture data with signed packages."
 	@echo "    fixtures/srpm-unsigned"
@@ -158,8 +158,7 @@ fixtures: fixtures/docker \
 	fixtures/rpm-missing-other \
 	fixtures/rpm-missing-primary \
 	fixtures/rpm-pkglists-updateinfo \
-    fixtures/rpm-richnweak-deps \
-    fixtures/rpm-richnweak-deps/srpms \
+	fixtures/rpm-richnweak-deps \
 	fixtures/rpm-signed \
 	fixtures/rpm-unsigned \
 	fixtures/rpm-updated-updateinfo \
@@ -168,6 +167,7 @@ fixtures: fixtures/docker \
 	fixtures/rpm-with-vendor \
 	fixtures/rpm-with-pulp-distribution \
 	fixtures/srpm \
+	fixtures/srpm-richnweak-deps \
 	fixtures/srpm-signed \
 	fixtures/srpm-unsigned
 
@@ -286,11 +286,8 @@ fixtures/rpm-signed: gnupghome
 fixtures/rpm-unsigned:
 	rpm/gen-fixtures.sh $@ rpm/assets
 
-fixtures/rpm-richnweak-deps/srpms:
-	rpm-richnweak-deps/gen-srpms.sh $@ rpm-richnweak-deps/assets-specs/*.spec
-
-fixtures/rpm-richnweak-deps: fixtures/rpm-richnweak-deps/srpms
-	rpm-richnweak-deps/gen-rpms.sh $@ $@/srpms/*.src.rpm
+fixtures/rpm-richnweak-deps: fixtures/srpm-richnweak-deps
+	rpm-richnweak-deps/gen-rpms.sh $@ $</*.src.rpm
 
 fixtures/rpm-updated-updateinfo:
 	rpm/gen-patched-fixtures.sh $@ rpm/updated-updateinfo.patch
@@ -326,6 +323,9 @@ fixtures/rpm-with-pulp-distribution:
 fixtures/srpm: fixtures/srpm-signed
 	$(warning The `fixtures/srpm` target is deprecated. Use `fixtures/srpm-signed` instead.)
 	ln -s ./srpm-signed $@
+
+fixtures/srpm-richnweak-deps:
+	rpm-richnweak-deps/gen-srpms.sh $@ rpm-richnweak-deps/assets-specs/*.spec
 
 fixtures/srpm-signed: gnupghome
 	GNUPGHOME=$$(realpath -e gnupghome) rpm/gen-fixtures.sh \

--- a/README.rst
+++ b/README.rst
@@ -144,11 +144,10 @@ See ``make help``.
 ``fixtures/rpm-unsigned``
     The ``createrepo`` and ``modifyrepo`` executables must be available.
 
-``fixtures/rpm-richnweak-deps/srpms``
-    The ``mock`` executable must be available.
-
 ``fixtures/rpm-richnweak-deps``
-    See ``fixtures/rpm-richnweak-deps/srpms``.
+    The ``mock`` and ``createrepo`` executable must be available.
+    All users that are to use mock must be added to the mock group.
+    ``usermod --append --groups mock "$(whoami)"``
 
 ``fixtures/rpm-updated-updateinfo``
     See ``fixtures/rpm-unsigned``.
@@ -167,6 +166,10 @@ See ``make help``.
 
 ``fixtures/rpm-with-pulp-distribution``
     See ``fixtures/rpm-unsigned``.
+
+``fixtures/srpm-richnweak-deps``
+    The ``rpmdev-setuptree``, ``rpmbuild`` and ``createrepo`` executable must be
+    available.
 
 ``fixtures/srpm-signed``
     The ``createrepo`` and ``modifyrepo`` executables must be available.

--- a/rpm-richnweak-deps/assets-specs/Cobbler.spec
+++ b/rpm-richnweak-deps/assets-specs/Cobbler.spec
@@ -25,5 +25,5 @@ Stir well and add bits of fresh fruit before serving
 %files
 
 %changelog
-* Tue Feb 27 2017 Mr. Bartender
-  - served
+* Tue Feb 27 2018 Mr. Bartender
+- served

--- a/rpm-richnweak-deps/assets-specs/PanAmerican.spec
+++ b/rpm-richnweak-deps/assets-specs/PanAmerican.spec
@@ -26,5 +26,5 @@ stir well and top off with Soda Water.
 %files
 
 %changelog
-* Tue Feb 27 2017 Mr. Bartender
-  - modified&served
+* Tue Feb 27 2018 Mr. Bartender
+- modified&served

--- a/rpm-richnweak-deps/assets-specs/bitter.spec
+++ b/rpm-richnweak-deps/assets-specs/bitter.spec
@@ -17,4 +17,4 @@ Suggests: (Cobbler or contireau)
 
 %changelog
 * Tue Feb 27 2018 Mr. Bartender
-  - described
+- described

--- a/rpm-richnweak-deps/assets-specs/bourbon5.spec
+++ b/rpm-richnweak-deps/assets-specs/bourbon5.spec
@@ -18,4 +18,4 @@ A corn-grain spirit
 
 %changelog
 * Tue Feb 27 2018 Mr. Bartender
-  - bought
+- bought

--- a/rpm-richnweak-deps/assets-specs/contireau2.spec
+++ b/rpm-richnweak-deps/assets-specs/contireau2.spec
@@ -18,4 +18,4 @@ A generic Contireau, nothing fancy.
 
 %changelog
 * Tue Feb 27 2018 Mr. Bartender
-  - bought
+- bought

--- a/rpm-richnweak-deps/assets-specs/fizzy.spec
+++ b/rpm-richnweak-deps/assets-specs/fizzy.spec
@@ -17,4 +17,4 @@ BuildArch:	noarch
 
 %changelog
 * Tue Feb 27 2018 Mr. Bartender
-  - described
+- described

--- a/rpm-richnweak-deps/assets-specs/fruity.spec
+++ b/rpm-richnweak-deps/assets-specs/fruity.spec
@@ -17,4 +17,4 @@ BuildArch:	noarch
 
 %changelog
 * Tue Feb 27 2018 Mr. Bartender
-  - described
+- described

--- a/rpm-richnweak-deps/assets-specs/icecubes.spec
+++ b/rpm-richnweak-deps/assets-specs/icecubes.spec
@@ -17,4 +17,4 @@ SSIA
 
 %changelog
 * Tue Feb 27 2018 Mr. Bartender
-  - frozen
+- frozen

--- a/rpm-richnweak-deps/assets-specs/leafrog8.spec
+++ b/rpm-richnweak-deps/assets-specs/leafrog8.spec
@@ -18,4 +18,4 @@ An old-school, froggy tasting Scotch.
 
 %changelog
 * Tue Feb 27 2018 Mr. Bartender
-  - estd.
+- estd.

--- a/rpm-richnweak-deps/assets-specs/lemon-juice5.spec
+++ b/rpm-richnweak-deps/assets-specs/lemon-juice5.spec
@@ -19,4 +19,4 @@ Properly washed and gently squeezed, fresh, fresh, fresh.
 
 %changelog
 * Tue Feb 27 2018 Mr. Bartender
-  - washed and squeezed
+- washed and squeezed

--- a/rpm-richnweak-deps/assets-specs/lemon-slice.spec
+++ b/rpm-richnweak-deps/assets-specs/lemon-slice.spec
@@ -18,4 +18,4 @@ Properly washed and thinly sliced, fresh, fresh, fresh.
 
 %changelog
 * Tue Feb 27 2018 Mr. Bartender
-  - washed and sliced
+- washed and sliced

--- a/rpm-richnweak-deps/assets-specs/lemon.spec
+++ b/rpm-richnweak-deps/assets-specs/lemon.spec
@@ -17,4 +17,4 @@ Provides:  lemon, citrussy, fruity
 
 %changelog
 * Tue Feb 27 2018 Mr. Bartender
-  - washed and squeezed
+- washed and squeezed

--- a/rpm-richnweak-deps/assets-specs/orange-bits.spec
+++ b/rpm-richnweak-deps/assets-specs/orange-bits.spec
@@ -18,4 +18,4 @@ Pealed and cut, fresh, fresh, fresh.
 
 %changelog
 * Tue Feb 27 2018 Mr. Bartender
-  - Freshly pealed, cut and packed.
+- Freshly pealed, cut and packed.

--- a/rpm-richnweak-deps/assets-specs/soda.spec
+++ b/rpm-richnweak-deps/assets-specs/soda.spec
@@ -18,4 +18,4 @@ Soda... Sort of a sparkling water.
 
 %changelog
 * Tue Feb 27 2018 Mr. Bartender
-  - Poured
+- Poured

--- a/rpm-richnweak-deps/assets-specs/tablespoon-sugar.spec
+++ b/rpm-richnweak-deps/assets-specs/tablespoon-sugar.spec
@@ -17,4 +17,4 @@ SSIA
 
 %changelog
 * Tue Feb 27 2018 Mr. Bartender
-  - scooped
+- scooped

--- a/rpm-richnweak-deps/gen-rpms.sh
+++ b/rpm-richnweak-deps/gen-rpms.sh
@@ -59,7 +59,7 @@ for srpm in "${@}"; do
     filename="${filename%.src.rpm}.noarch.rpm"
     cp "/var/lib/mock/${mock_env}/result/${filename}" "${working_dir}/"
 done
-
+createrepo --checksum sha256 "${working_dir}"
 # Create or populate $output_dir.
 #
 # A $working_dir is used to make fixture generation more atomic. If fixture

--- a/rpm-richnweak-deps/gen-srpms.sh
+++ b/rpm-richnweak-deps/gen-srpms.sh
@@ -60,6 +60,7 @@ for specfile in "${@}"; do
     filename="$(rpm --query --queryformat '%{NEVR}.src.rpm' --specfile "${specfile}")"
     cp ~/rpmbuild/SRPMS/"${filename}" "${working_dir}"/
 done
+createrepo --checksum sha256 "${working_dir}"
 
 # Create or populate $output_dir.
 #


### PR DESCRIPTION
Fix error related to dates on rpm specs.

Fix dependenies for `rpm-richnweak-deps` and `srpm-richnweak-deps` scripts.

Add `createrepo` to generate metadata for the previous mentioned
scripts.

Add instructions about the proper use of mock.

Fix:#91