### PR TITLE
Modify the RPM specs for rich and weak dependencies.

### DIFF
--- a/rpm-richnweak-deps/assets-specs/Cobbler.spec
+++ b/rpm-richnweak-deps/assets-specs/Cobbler.spec
@@ -9,7 +9,7 @@ Group:  Cocktails
 URL:  http://www.cocktails.in.th/whiskey.html
 Requires: (scotch == 8.10 and contireau == 2.10 and tablespoon-sugar == 1.0), icecubes
 Recommends: (orange-bits if fruity)
-Provides: long-drink, scotch, fruity, citrussy, bitter
+Provides: long-drink, scotch, fruity, citrussy, bitter, Cobbler
 BuildArch:	noarch
 
 %description

--- a/rpm-richnweak-deps/assets-specs/PanAmerican.spec
+++ b/rpm-richnweak-deps/assets-specs/PanAmerican.spec
@@ -10,7 +10,7 @@ URL:  http://www.cocktails.in.th/whiskey.html
 Requires: (bourbon == 5.10 and tablespoon-sugar == 1.0)
 Requires: soda, lemon-juice5 = 5.10
 Recommends: (lemon-slice if fruity)
-Provides: long-drink, bourbon, citrussy, lemon, fruity, fizzy
+Provides: long-drink, bourbon, citrussy, lemon, fruity, fizzy, PanAmerican
 BuildArch:	noarch
 
 %description

--- a/rpm-richnweak-deps/assets-specs/bitter.spec
+++ b/rpm-richnweak-deps/assets-specs/bitter.spec
@@ -9,6 +9,7 @@ Group:  Preferences
 URL:  http://you.yourself.thou/Preference/
 BuildArch:	noarch
 Suggests: (Cobbler or contireau)
+Provides: bitter
 
 %description
 ... usually felt when one want to satisfy their Bitter passions ...

--- a/rpm-richnweak-deps/assets-specs/contireau2.spec
+++ b/rpm-richnweak-deps/assets-specs/contireau2.spec
@@ -8,7 +8,7 @@ Vendor:	 Contireauers
 Group:  Cocktails
 URL:  http://contireaue.rs/Contireau
 BuildArch:	noarch
-Provides: citrussy, fruity, bitter
+Provides: citrussy, fruity, bitter, contireau
 Suggests: (Cobbler)
 
 %description

--- a/rpm-richnweak-deps/assets-specs/fizzy.spec
+++ b/rpm-richnweak-deps/assets-specs/fizzy.spec
@@ -8,6 +8,7 @@ Vendor:	 You
 Group:  Preferences
 URL:  http://you.yourself.thou/Preference/
 Suggests: (PanAmerican or soda)
+Provides: fizzy
 BuildArch:	noarch
 
 %description

--- a/rpm-richnweak-deps/assets-specs/fruity.spec
+++ b/rpm-richnweak-deps/assets-specs/fruity.spec
@@ -8,6 +8,7 @@ Vendor:	 You
 Group:  Preferences
 URL:  http://you.yourself.thou/Preference/
 Suggests: (orange-bits or lemon-jiuce)
+Provides: fruity
 BuildArch:	noarch
 
 %description

--- a/rpm-richnweak-deps/assets-specs/lemon-juice5.spec
+++ b/rpm-richnweak-deps/assets-specs/lemon-juice5.spec
@@ -8,7 +8,7 @@ Vendor:	 Lem:ON!
 Group:  Fruits
 URL:  http://lem.on/Fruits/
 BuildArch:	noarch
-Provides: lemon, citrussy, juice, fruity
+Provides: lemon, citrussy, juice, fruity, lemon-juice5
 Requires: lemon
 Suggests: (PanAmerican)
 

--- a/rpm-richnweak-deps/assets-specs/lemon-slice.spec
+++ b/rpm-richnweak-deps/assets-specs/lemon-slice.spec
@@ -8,7 +8,7 @@ Vendor:	 Lem:ON!
 Group:  Fruits
 URL:  http://lem.on/Fruits/
 BuildArch:	noarch
-Provides: lemon, citrussy, fruity
+Provides: lemon, citrussy, fruity, lemon-slice
 Requires: lemon
 
 %description

--- a/rpm-richnweak-deps/assets-specs/scotch.spec
+++ b/rpm-richnweak-deps/assets-specs/scotch.spec
@@ -1,5 +1,5 @@
 Summary: The Leafrog Scotch
-Name:	 leafrog
+Name:	 scotch
 Version:	8
 Release:	10
 License:	21+


### PR DESCRIPTION
Fix what each RPM spec provides and fix names for specs.

Using this new specs. dnf was able to install `Cobbler` an
`PanAmerican`, and its dependencies as well.

Fix:#95