### PR TITLE
Fix #97 - Cobbler and PanAmerican are now bringing all the Requires

### DIFF
--- a/rpm-richnweak-deps/README.md
+++ b/rpm-richnweak-deps/README.md
@@ -10,13 +10,13 @@ expressed thru the boolean dependencies within their package ``spec`` files.
 Usage
 ------
 
-Say you'd like to have a refreshing, citrussy and bitter tasting, scotch-based
+Say you'd like to have a refreshing, citrussy and bitter tasting, Scotch-based
 long drink. Assuming your repository contains the necessary ingredients and
 your system is configured with the proper feed, you could query the repository
 for just that:
 
 ```
-$ dnf -b whatprovides citrussy bitter fruity scotch long-drink
+$ dnf -b whatprovides citrussy bitter fruity Scotch long-drink
 ```
 
 Ideally, your query result would look something like:
@@ -28,7 +28,7 @@ Matched from:
 Provide    : citrussy
 Provide    : long-drink
 Provide    : fruity
-Provide    : scotch
+Provide    : Scotch
 Provide    : bitter
 
 $ dnf info Cobbler
@@ -65,7 +65,7 @@ $ sudo dnf --setopt=install_weak_dependencies=False --best instal Cobbler
 If you prefer your bartender to select on your behalf:
 
 ```
-$ sudo dnf --best install long-drink scotch fruity
+$ sudo dnf --best install long-drink Scotch fruity
 ```
 
 that should, thanks to the (weak) rich dependencies, result in getting

--- a/rpm-richnweak-deps/assets-specs/Cobbler.spec
+++ b/rpm-richnweak-deps/assets-specs/Cobbler.spec
@@ -1,16 +1,16 @@
 Summary: The Cobbler drink
-Name:	 Cobbler
-Version:	1
-Release:	0
-License:	21+
-Packager:	 Mr. Bartender
-Vendor:	 ReFresh Cocktails
-Group:  Cocktails
-URL:  http://www.cocktails.in.th/whiskey.html
-Requires: (scotch == 8.10 and contireau == 2.10 and tablespoon-sugar == 1.0), icecubes
+Name: Cobbler
+Version: 1
+Release: 0
+License: 21+
+Packager: Mr. Bartender
+Vendor: ReFresh Cocktails
+Group: Cocktails
+URL: http://www.cocktails.in.th/whiskey.html
+Requires: (Scotch == 8-10 and contireau == 2-10 and tablespoon-sugar == 1-0), icecubes
 Recommends: (orange-bits if fruity)
-Provides: long-drink, scotch, fruity, citrussy, bitter, Cobbler
-BuildArch:	noarch
+Provides: long-drink, fruity, citrussy, bitter, Cobbler
+BuildArch: noarch
 
 %description
 A refreshing long drink that can be prepared in advance, so that the fruit can soak up some of the taste and alcohol.

--- a/rpm-richnweak-deps/assets-specs/PanAmerican.spec
+++ b/rpm-richnweak-deps/assets-specs/PanAmerican.spec
@@ -10,7 +10,7 @@ URL:  http://www.cocktails.in.th/whiskey.html
 Requires: (bourbon == 5.10 and tablespoon-sugar == 1.0)
 Requires: soda, lemon-juice5 = 5.10
 Recommends: (lemon-slice if fruity)
-Provides: long-drink, bourbon, citrussy, lemon, fruity, fizzy, PanAmerican
+Provides: long-drink, citrussy, lemon, fruity, fizzy, PanAmerican
 BuildArch:	noarch
 
 %description

--- a/rpm-richnweak-deps/assets-specs/scotch.spec
+++ b/rpm-richnweak-deps/assets-specs/scotch.spec
@@ -1,5 +1,5 @@
 Summary: The Leafrog Scotch
-Name:	 scotch
+Name:	 Scotch
 Version:	8
 Release:	10
 License:	21+
@@ -8,7 +8,7 @@ Vendor:	 Leafrog stills
 Group:  Cocktails
 URL:  http://leafrogstil.ls/Leafrog
 BuildArch:	noarch
-Provides: scotch
+Provides: Scotch
 Suggests: (Cobbler)
 
 %description


### PR DESCRIPTION
- Renamed scotch to Scotch (avoid conflict with existing scotch package)
- Removes Scotch from `Provides` for Cobbler and PanAmerican as a package cannot be listed as a Requirement at the same time it is providing it.

Tested with locally generated fixtures and passed for PulpQE/Pulp-2-Tests#44.

```bash
py.test -v --color=yes --pyargs pulp_2_tests.tests.rpm.api_v2.test_rich_weak_dependencies
============================================================= test session starts ==============================================================
collected 5 items

pulp_2_tests/tests/rpm/api_v2/test_rich_weak_dependencies.py::SyncPublishTestCase::test_rpm PASSED                                       [ 20%]
pulp_2_tests/tests/rpm/api_v2/test_rich_weak_dependencies.py::SyncPublishTestCase::test_srpm PASSED                                      [ 40%]
pulp_2_tests/tests/rpm/api_v2/test_rich_weak_dependencies.py::UploadRPMTestCase::test_all PASSED                                         [ 60%]
pulp_2_tests/tests/rpm/api_v2/test_rich_weak_dependencies.py::PackageManagerCosumeRPMTestCase::test_all PASSED                           [ 80%]
pulp_2_tests/tests/rpm/api_v2/test_rich_weak_dependencies.py::CopyRecursiveUnitsTestCase::test_all PASSED

==== 5 passed in 60.01 seconds =====

```