### PR TITLE
Adding `sha 512` checksum logic for generating fixtures.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,8 @@ help:
 	@echo "        Create an RPM file with non-ascii characters."
 	@echo "    fixtures/rpm-with-non-utf-8"
 	@echo "        Create an RPM file with non-utf-8 characters."
+	@echo "    fixtures/rpm-with-sha-512"
+	@echo "        Create RPM fixture data with checksum as 'sha512'."
 	@echo "    fixtures/rpm-with-pulp-distribution"
 	@echo "        Create an RPM repository with extra files and a"
 	@echo "        PULP_DISTRIBUTION.xml file."
@@ -161,6 +163,7 @@ fixtures: fixtures/docker \
 	fixtures/rpm-updated-updateinfo \
 	fixtures/rpm-with-non-ascii \
 	fixtures/rpm-with-non-utf-8 \
+	fixtures/rpm-with-sha-512 \
 	fixtures/rpm-with-vendor \
 	fixtures/rpm-with-pulp-distribution \
 	fixtures/srpm-richnweak-deps \
@@ -285,6 +288,9 @@ fixtures/rpm-with-non-ascii:
 
 fixtures/rpm-with-non-utf-8:
 	rpm/gen-rpm.sh $@ "rpm/assets-specs/$$(basename $@).spec"
+
+fixtures/rpm-with-sha-512:
+	rpm/gen-fixtures.sh --checksum-type "sha512" $@ rpm/assets
 
 fixtures/rpm-with-vendor:
 	rpm/gen-rpm-and-repo.sh $@ "rpm/assets-specs/$$(basename $@).spec"

--- a/rpm/gen-fixtures.sh
+++ b/rpm/gen-fixtures.sh
@@ -30,6 +30,10 @@ Options:
         repository. If not specified, packages are placed in the root of the
         repository. Passing \`--packages-dir .\` is equivalent to the default
         action.
+    --checksum-type <type>
+        The type of checksum that has to be included in repomd while using the
+        $(createrepo) command. Default checksum type is sha256.
+
 EOF
 }
 
@@ -37,7 +41,7 @@ EOF
 check_getopt
 temp=$(getopt \
     --options '' \
-    --longoptions signing-key:,packages-dir: \
+    --longoptions signing-key:,packages-dir:,checksum-type: \
     --name "$script_name" \
     -- "$@")
 eval set -- "$temp"
@@ -52,6 +56,7 @@ while true; do
     case "$1" in
         --signing-key) signing_key="$(realpath --canonicalize-existing "$2")"; shift 2;;
         --packages-dir) packages_dir="$2"; shift 2;;
+        --checksum-type) checksum_type="$2"; shift 2;;
         --) shift; break;;
         *) echo "Internal error! Encountered unexpected argument: $1"; exit 1;;
     esac
@@ -81,7 +86,8 @@ if [ -n "${signing_key:-}" ]; then
         --define '_gpg_name Pulp QE' --addsign --fskpath "${signing_key}" \
         --signfiles
 fi
-createrepo --checksum sha256 \
+checksum_type_default=sha256
+createrepo --checksum "${checksum_type:-${checksum_type_default}}" \
     --groupfile "$(realpath --relative-to "${working_dir}" "${assets_dir}/comps.xml")" \
     "${working_dir}"
 modifyrepo --mdtype updateinfo \


### PR DESCRIPTION
A user should be able to sync rpm packages that has sha 512 checksums in
the pulp repo. The current pulp repo is checksumed with only one type
`sha 256`. This commit will add logic for changing the checksum type of
the created repo by passing a parameter `--checksum-type` in the
`gen-fixtures.sh`

refer https://pulp.plan.io/issues/4007
Closes #60