### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,13 +11,7 @@ before_install:
     - pip install --upgrade pip
     - pip install pylint
     - deactivate
-    - cabal update
-    - git clone https://github.com/koalaman/shellcheck.git
-    - cd shellcheck
-    - git checkout v0.4.4
-    - cabal install
-    - cd ..
-    - export PATH="$HOME/.cabal/bin:$PATH"
+    - sudo apt-get install -y shellcheck
     - which shellcheck
     - source ~/env/bin/activate
 script:

--- a/ostree/gen-fixtures.sh
+++ b/ostree/gen-fixtures.sh
@@ -29,7 +29,7 @@ show_help()
 _mkdir()
 {
   if [ -e "${DIR}" ]; then
-    if [ ! -z "$(ls -A "${DIR}")" ]; then
+    if [ -n "$(ls -A "${DIR}")" ]; then
       echo 1>&2 ""
       echo 1>&2 "${DIR} must be empty."
       echo 1>&2 ""


### PR DESCRIPTION
Update .travis.yml to install shellcheck using package manager. There
was a problem and the shellcheck version was pinned before.
The problem has been solved, and shellcheck is currently in the version
`0.6.0`.

Besides that, update new error found using the new version of
shellcheck.

See: https://github.com/koalaman/shellcheck/releases/tag/v0.6.0