### PR TITLE
Adding sha1 modular content to fixtures repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,8 @@ help:
 	@echo "        Create an RPM file with non-utf-8 characters."
 	@echo "    fixtures/rpm-with-sha-512"
 	@echo "        Create RPM fixture data with checksum as 'sha512'."
+	@echo "    fixtures/rpm-with-sha-1-modular"
+	@echo "        Create RPM Modules fixture data with checksum as 'sha1'."
 	@echo "    fixtures/rpm-with-pulp-distribution"
 	@echo "        Create an RPM repository with extra files and a"
 	@echo "        PULP_DISTRIBUTION.xml file."
@@ -164,6 +166,7 @@ fixtures: fixtures/docker \
 	fixtures/rpm-with-non-ascii \
 	fixtures/rpm-with-non-utf-8 \
 	fixtures/rpm-with-sha-512 \
+	fixtures/rpm-with-sha-1-modular \
 	fixtures/rpm-with-vendor \
 	fixtures/rpm-with-pulp-distribution \
 	fixtures/srpm-richnweak-deps \
@@ -291,6 +294,10 @@ fixtures/rpm-with-non-utf-8:
 
 fixtures/rpm-with-sha-512:
 	rpm/gen-fixtures.sh --checksum-type "sha512" $@ rpm/assets
+
+fixtures/rpm-with-sha-1-modular:
+	rpm/gen-patched-fixtures.sh $@ rpm/modules-updateinfo.patch sha1
+	modifyrepo --mdtype=modules rpm/assets/modules.yaml "$@/repodata/"
 
 fixtures/rpm-with-vendor:
 	rpm/gen-rpm-and-repo.sh $@ "rpm/assets-specs/$$(basename $@).spec"

--- a/rpm/gen-patched-fixtures.sh
+++ b/rpm/gen-patched-fixtures.sh
@@ -23,6 +23,10 @@ set -euo pipefail
 # Read arguments.
 output_dir="${1}"
 updateinfo_patch=$(realpath "${2}")
+checksum_info="sha256"
+if [ -n "${3:-}" ]; then
+    checksum_info="${3}"
+fi
 
 # Define a procedure for graceful termination.
 cleanup() {
@@ -38,4 +42,4 @@ trap 'cleanup ; trap - SIGTERM ; kill -s SIGTERM $$' SIGTERM
 assets_dir="$(mktemp --directory)"
 cp -rt "${assets_dir}" rpm/assets/*
 patch "${assets_dir}/updateinfo.xml" "${updateinfo_patch}"
-./rpm/gen-fixtures.sh "${output_dir}" "${assets_dir}"
+./rpm/gen-fixtures.sh --checksum-type "${checksum_info}" "${output_dir}" "${assets_dir}"


### PR DESCRIPTION
This commit takes care of creating a fixtures repo with modular rpm
checksumed with sha1. This will be used for testing Pulp #4351