### PR TITLE
Change the size of generate file fixtures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -195,7 +195,7 @@ fixtures/file-invalid:
 	echo 4.iso,4a36e4eede4a61fd547040b53b1656b6dd489bd5bc4c0dd5fe55892dcf1669e8,1048576 >> $@/PULP_MANIFEST
 
 fixtures/file-large:
-	file/gen-fixtures.sh $@ --number 10
+	file/gen-fixtures.sh $@ --number 10 --file-size 10M
 
 fixtures/file-many:
 	file/gen-fixtures.sh $@ --number 250

--- a/file/gen-fixtures.sh
+++ b/file/gen-fixtures.sh
@@ -23,6 +23,8 @@ but all parent directories must exist.
 Options:
     --number <integer>
         The number of ISO files to generate. Default: 3.
+    --file-size <size>
+        The size of ISO files to generate. Default: 1K.
 EOF
 }
 
@@ -30,11 +32,12 @@ EOF
 check_getopt
 temp=$(getopt \
     --options '' \
-    --longoptions number:, \
+    --longoptions number:,file-size: \
     --name "$script_name" \
     -- "$@")
 eval set -- "$temp"
 unset temp
+
 
 # Read arguments. (getopt inserts -- even when no arguments are passed.)
 if [ "${#@}" -eq 1 ]; then
@@ -44,6 +47,7 @@ fi
 while true; do
     case "$1" in
         --number) number="$2"; shift 2;;
+        --file-size) file_size="$2"; shift 2;;
         --) shift; break;;
         *) echo "Internal error! Encountered unexpected argument: $1"; exit 1;;
     esac
@@ -61,9 +65,10 @@ working_dir="$(mktemp --directory)"
 
 # Create the pseudo ISO files and update the PULP_MANIFEST with the generated
 # file information
+file_size="${file_size:-1K}"
 for ((i=0; i<number; i++)); do
     of="${working_dir}/$((i + 1)).iso"
-    dd if=/dev/urandom of="${of}" bs=1K count=1
+    dd if=/dev/urandom of="${of}" bs="${file_size}" count=1
     echo "$(basename "${of}"),$(sha256sum "${of}" | awk '{print $1}'),$(stat -c '%s' "${of}")" \
     >> "${working_dir}/PULP_MANIFEST"
 done


### PR DESCRIPTION
Add a new optional flag `--file-size` to specify the size of created
files.
Besides that, modify the fixtures/file-large to generate 10M files.

closes: #112