### PR TITLE
Adding srpm-duplicate fixture to address #4459

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,8 @@ help:
 	@echo "        PULP_DISTRIBUTION.xml file."
 	@echo "    fixtures/rpm-with-vendor"
 	@echo "        Create an RPM repository with an RPM that has a vendor."
+	@echo "    fixtures/srpm-duplicate"
+	@echo "        Create SRPM fixture data with duplicate entries in repodata."
 	@echo "    fixtures/srpm-richnweak-deps"
 	@echo "        Create SRPM fixture data with packages with regular,"
 	@echo "        weak and very weak dependencies."
@@ -169,9 +171,11 @@ fixtures: fixtures/docker \
 	fixtures/rpm-with-sha-1-modular \
 	fixtures/rpm-with-vendor \
 	fixtures/rpm-with-pulp-distribution \
+	fixtures/srpm-duplicate \
 	fixtures/srpm-richnweak-deps \
 	fixtures/srpm-signed \
 	fixtures/srpm-unsigned
+
 
 fixtures/docker:
 	docker/gen-fixtures.sh $@
@@ -316,6 +320,11 @@ fixtures/rpm-with-pulp-distribution:
 	echo "family=Zoo" >> $@/treeinfo
 	echo "timestamp=1485887759" >> $@/treeinfo
 	echo "version=42" >> $@/treeinfo
+
+fixtures/srpm-duplicate:
+	rpm-richnweak-deps/gen-srpms.sh $@/src srpm-duplicate/assets-specs/*.spec
+	rpm-richnweak-deps/gen-srpms.sh $@/dst srpm-duplicate/assets-specs/*.spec
+	createrepo --checksum sha256 $@
 
 fixtures/srpm-richnweak-deps:
 	rpm-richnweak-deps/gen-srpms.sh $@ rpm-richnweak-deps/assets-specs/*.spec

--- a/README.rst
+++ b/README.rst
@@ -170,6 +170,9 @@ See ``make help``.
 ``fixtures/rpm-with-pulp-distribution``
     See ``fixtures/rpm-unsigned``.
 
+``fixtures/srpm-duplicate``
+    See ``fixtures/srpm-richnweak-deps``.
+
 ``fixtures/srpm-richnweak-deps``
     The ``rpmdev-setuptree``, ``rpmbuild`` and ``createrepo`` executable must be
     available.

--- a/srpm-duplicate/assets-specs/australianShepherd.spec
+++ b/srpm-duplicate/assets-specs/australianShepherd.spec
@@ -1,0 +1,20 @@
+Summary: Australian Shepherd
+Name:	 australianShepherd
+Version:	1
+Release:	0
+License:	No Age Limitation
+Packager:	ASPCA
+Vendor:	Smart Dogs
+Group:  Intelligence Animals
+URL:  https://www.akc.org/dog-breeds/australian-shepherd/
+BuildArch:	noarch
+Suggests: (borderCollie)
+Provides: australianShepherd
+
+%description
+The Australian Shepherd is an intelligent working dog of strong herding and guarding instincts. He is a loyal companion and has the stamina to work all day. He is well balanced, slightly longer than tall, of medium size and bone, with coloring that offers variety and individuality. He is attentive and animated, lithe and agile, solid and muscular without cloddiness. He has a coat of moderate length and coarseness. He has a docked or natural bobbed tail.
+%files
+
+%changelog
+* Wed Feb 28 2018 ASPCA
+- Initial add-in of the australianShepherd

--- a/srpm-duplicate/assets-specs/borderCollie.spec
+++ b/srpm-duplicate/assets-specs/borderCollie.spec
@@ -1,0 +1,23 @@
+Summary: Border Collie
+Name:	 borderCollie
+Version:	1
+Release:	2
+License:	No Age Limitation
+Packager:	ASPCA
+Vendor:	Sneaky Dogs
+Group:  Intelligence Animals
+URL:  https://www.akc.org/dog-breeds/border-collie/
+BuildArch:	noarch
+Suggests: (australianShepherd)
+Provides: borderCollie
+
+%description
+The Border Collie is a well balanced, medium-sized dog of athletic appearance, displaying style and agility in equal measure with soundness and strength. Its hard, muscular body conveys the impression of effortless movement and endless endurance. The Border Collie is extremely intelligent, with its keen, alert expression being a very important characteristic of the breed. Any aspect of structure or temperament that would impede the dog’s ability to function as a herding dog should be severely faulted. The Border Collie is, and should remain, a natural and unspoiled true working sheepdog whose conformation is described herein. Honorable scars and broken teeth incurred in the line of duty are acceptable.
+
+%files
+
+%changelog
+* Fri Mar 1 2019 ASPCA
+- He sneaks in again! A double! This breaks SRPM Pulp! #4397
+* Thu Feb 28 2019 ASPCA
+- Initial add-in of the borderCollie


### PR DESCRIPTION
Issue #4459 addresses when there is duplicate SRPMs in the repodata that pulp would error out in the sync when `--skip srpm` was used in repo creation.

The following are the modifications:
- Adding two new SRPMS from .spec that are used for testing
- Updating Makefile to create two separate folders containing RPMs
- Run createrepo_c on the make to have repodata have two entries
  for the same RPM version in the primary.yaml
- Updated README with information on the new fixture

refs #4459