### PR TITLE
Commenting out the creation of pulp-fixtures puppet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,6 @@ fixtures: fixtures/docker \
 	fixtures/file-large\
 	fixtures/file-many\
 	fixtures/file-mixed \
-	fixtures/puppet \
 	fixtures/python-pypi \
 	fixtures/rpm-alt-layout \
 	fixtures/rpm-with-modules \
@@ -166,7 +165,6 @@ fixtures: fixtures/docker \
 	fixtures/rpm-unsigned \
 	fixtures/rpm-updated-updateinfo \
 	fixtures/rpm-with-non-ascii \
-	fixtures/rpm-with-non-utf-8 \
 	fixtures/rpm-with-sha-512 \
 	fixtures/rpm-with-sha-1-modular \
 	fixtures/rpm-with-vendor \
@@ -212,8 +210,9 @@ fixtures/file-mixed:
 fixtures/ostree:
 	ostree/gen-fixtures.sh $@/small
 
-fixtures/puppet:
-	puppet/gen-module.sh $@
+# Commented out AND removved from the generation: See SATQE-3469
+# fixtures/puppet:
+# 	puppet/gen-module.sh $@
 
 fixtures/python-pypi:
 	python/gen-pypi-repo.sh $@ python/pypi-assets $(base_url)
@@ -293,8 +292,9 @@ fixtures/rpm-with-modules:
 fixtures/rpm-with-non-ascii:
 	rpm/gen-rpm.sh $@ "rpm/assets-specs/$$(basename $@).spec"
 
-fixtures/rpm-with-non-utf-8:
-	rpm/gen-rpm.sh $@ "rpm/assets-specs/$$(basename $@).spec"
+# Commented out AND removed from the generation: See SATQE-3484
+# fixtures/rpm-with-non-utf-8:
+# 	rpm/gen-rpm.sh $@ "rpm/assets-specs/$$(basename $@).spec"
 
 fixtures/rpm-with-sha-512:
 	rpm/gen-fixtures.sh --checksum-type "sha512" $@ rpm/assets

--- a/rpm-richnweak-deps/gen-rpms.sh
+++ b/rpm-richnweak-deps/gen-rpms.sh
@@ -8,7 +8,7 @@ source rpm-richnweak-deps/common.sh
 # See: http://mywiki.wooledge.org/BashFAQ/028
 readonly script_name='gen-rpms.sh'
 
-readonly mock_env=fedora-26-x86_64
+readonly mock_env=fedora-30-x86_64
 
 # Print usage instructions to stdout.
 show_help() {

--- a/rpm-richnweak-deps/gen-srpms.sh
+++ b/rpm-richnweak-deps/gen-srpms.sh
@@ -51,7 +51,7 @@ working_dir="$(mktemp --directory)"
 # Populate ~/rpmbuild/SRPMS/
 rpmdev-setuptree
 for specfile in "${@}"; do
-    rpmbuild -bs --target fc26 "${specfile}" &
+    rpmbuild -bs --target fc30 "${specfile}" &
 done
 wait
 


### PR DESCRIPTION
# Background
The base image `pulp-fixtures` was using for *long time* has been f26. A newer and unified base image was desired to reduce our base image templates. Also, zchunks requires a newer F30 image.

Need these changes pushed in so other `pulp-fixture` playbook changes can be verified and the job is green again.

# Problem
When updating this image, there are the following issues:

There is an issue generating the puppet fixtures that is not a trivial fix. The work to add puppet fixture generation is being tracked by SATQE-3469.

There is an issue generating an RPM fixture with UTF-8 that is not a trivial fix. The Work to add back this one generation is being tracked by SATQE-3484.

# Solutions
This commit gets the building of all other fixtures functioning and rsyncing again with F30 which unblocks an outstanding PR/functional test for createrepo_c testing in:
- https://pulp.plan.io/issues/4530
- https://github.com/PulpQE/pulp-fixtures/issues/120

# References
See: https://projects.engineering.redhat.com/browse/SATQE-3467