### PR TITLE
Adding to duck module definition for modular copy regression

### DIFF
--- a/rpm/assets/modules.yaml
+++ b/rpm/assets/modules.yaml
@@ -142,6 +142,83 @@ data:
 document: modulemd
 version: 2
 data:
+  name: duck
+  stream: 4
+  version: 20190619105003
+  context: deadbeef
+  arch: noarch
+  summary: duck:4 stream
+  description: >-
+    A module stream for the duck 0.8 package
+    with a profile name of 'daffy'
+  license:
+    module:
+      - MIT
+  profiles:
+    default:
+      rpms:
+        - duck
+  artifacts:
+    rpms:
+      - duck-0:0.8-1.noarch
+...
+---
+document: modulemd
+version: 2
+data:
+  name: duck
+  stream: 5
+  version: 20190621095605
+  context: deadbeef
+  arch: noarch
+  summary: duck:5 stream
+  description: >-
+    A module stream for the duck 0.8 package
+    with a profile name of 'daffy'.
+    Ensures different streams with similar
+    RPM artifacts are not libsolv'd on copy.
+  license:
+    module:
+      - MIT
+  profiles:
+    default:
+      rpms:
+        - duck
+  artifacts:
+    rpms:
+      - duck-0:0.8-1.noarch
+...
+---
+document: modulemd
+version: 2
+data:
+  name: duck
+  stream: 6
+  version: 20190621095706
+  context: deadbeef
+  arch: noarch
+  summary: duck:6 stream
+  description: >-
+    A module stream for the duck 0.8 and frog 0.1 package
+    with a profile name of 'taffy'.
+    Ensures different streams with similar RPM artifacts are not
+    libsolv'd on copy.
+  license:
+    module:
+      - MIT
+  profiles:
+    default:
+      rpms:
+        - duck
+  artifacts:
+    rpms:
+      - duck-0:0.8-1.noarch
+      - frog-0:0.1-1.noarch
+...
+---
+document: modulemd
+version: 2
+data:
   name: walrus
   stream: 5.21
   version: 20180704144203
@@ -205,6 +282,9 @@ data:
   stream: 0
   profiles:
     0: [default]
+    4: [daffy]
+    5: [laffy]
+    6: [taffy]
 ...
 ---
 document: modulemd-defaults


### PR DESCRIPTION
## Note
The updates have already been checked and uploaded/rsync'd into ``rpm-with-modules``.

Run the test_modularity::CopyModulesTestCase to verify cases

## Problem
For the additional tests added to #4995, the pulp-fixture is updated with the duck module.

## Solution
* Added duck:4 which provides a simple module to copy with 0 ursine RPM dependencies
* Added duck:5 which is a different stream with the same Modular RPM dependencies. Should not be shadow copied by the libsolv fix
* Added duck:6 which is different than duck:4 by one Modular RPM variation. Should not be shadow copied by the libsolv fix.

## References 
* https://pulp.plan.io/issues/4995

refs #4995